### PR TITLE
Allow any subdirs

### DIFF
--- a/models/helpers.js
+++ b/models/helpers.js
@@ -14,7 +14,7 @@ e.isInteger = function(callBack,i) {
 }
 
 e.isValidDockerLink = function(callBack,i) {
-  var regexp = /^([a-zA-Z0-9.-]*)(\/?([a-z0-9.-]{1,63}))*:?([a-zA-Z0-9.-]*)$/
+  var regexp = /^([a-zA-Z0-9.-]*)(\/?([a-z0-9.-]{1,63}))+:?([a-zA-Z0-9.-]*)$/
   callBack(regexp.test(i));
 }
 

--- a/models/helpers.js
+++ b/models/helpers.js
@@ -14,7 +14,7 @@ e.isInteger = function(callBack,i) {
 }
 
 e.isValidDockerLink = function(callBack,i) {
-  var regexp = /^([a-zA-Z0-9.-]*)\/?([a-z0-9.-]{1,63}):?([a-zA-Z0-9.-]*)$/
+  var regexp = /^([a-zA-Z0-9.-]*)(\/?([a-z0-9.-]{1,63}))*:?([a-zA-Z0-9.-]*)$/
   callBack(regexp.test(i));
 }
 

--- a/tests/helpers.spec.js
+++ b/tests/helpers.spec.js
@@ -36,6 +36,8 @@ describe('isValidDockerLink', () => {
     it('should return false for invalid links', () => helpers.isValidDockerLink(expectFalse, ':foo'));
     it('should return false for invalid links', () => helpers.isValidDockerLink(expectFalse, 'foo_bar:0.1.1'));
     it('should return false for invalid links', () => helpers.isValidDockerLink(expectTrue, 'foo-bar:0.1.1'));
+    it('should return false for invalid links', () => helpers.isValidDockerLink(expectTrue, 'garbage/foo-bar:0.1.1'));
+    it('should return false for invalid links', () => helpers.isValidDockerLink(expectTrue, 'garbage.io/garbage/foo-bar:0.1.1'));
 });
 
 describe('isValidPort', () => {


### PR DESCRIPTION
we need to be able to use docker repos that container subdirectories for the images.

example  `quay.io/turner/hello-world` is failing right now. 