### PR TITLE
Roll build token

### DIFF
--- a/endpoints/endpoints.js
+++ b/endpoints/endpoints.js
@@ -8,49 +8,59 @@ requestHandlers.setMongoose(genE.m);
 var genEndpoints = [];
 
 var manualEndpoints = [
-  {
-    path:        '/v1/shipments',
-    type:        'get',
-    function:    requestHandlers.getAllShipments,
-    description: 'Returns an array of all shipments',
-    fields: []
-  },
-  {
-    path:        '/v1/shipment/:name',
-    type:        'get',
-    function:    requestHandlers.getShipment,
-    description: 'Returns an object with information about a particular shipment',
-    fields: []
-  },
-  {
-    path:        '/v1/shipment/:Shipment/environment/:name',
-    type:        'get',
-    function:    requestHandlers.getEnvironment,
-    description: 'Returns an environment object, with a parentShipment field containing the parent shipment',
-    fields: []
-  },
-  {
-    path:        '/v1/envVar/search',
-    type:        'get',
-    function:    requestHandlers.searchEnvVars,
-    description: 'Returns a shipment environment, that contains the envVar name and value',
-    fields: []
-  },
-  {
-    path:        '/v1/logs/shipment/:Shipment/environment/:Environment',
-    type:        'get',
-    function:    requestHandlers.getShipmentEnvironmentLogs,
-    description: 'Returns the changes for a shipment and environment pair.',
-    fields: []
-  },
-  {
-    path:        '/v1/logs/shipment/:Shipment',
-    type:        'get',
-    function:    requestHandlers.getShipmentLogs,
-    description: 'Returns all changes for a shipment. Same as searching /v1/logs/shipment/:Shipment/environment/parent',
-    fields: []
-  }
-]
+    {
+        "path":         '/v1/shipments',
+        "type":         'get',
+        "function":     requestHandlers.getAllShipments,
+        "description":  'Returns an array of all shipments',
+        "fields":       []
+    },
+    {
+        "path":         '/v1/shipment/:name',
+        "type":         'get',
+        "function":     requestHandlers.getShipment,
+        "description":  'Returns an object with information about a particular shipment',
+        "fields":       []
+    },
+    {
+        "path":         '/v1/shipment/:Shipment/environment/:name',
+        "type":         'get',
+        "function":     requestHandlers.getEnvironment,
+        "description":  'Returns an environment object, with a parentShipment field containing the parent shipment',
+        "fields":       []
+    },
+    {
+        "path":         '/v1/shipment/:Shipment/environment/:name/buildToken',
+        "type":         'put',
+        "function":     requestHandlers.rollBuildToken,
+        "description":  'Rolls the build token for this Shipment. Returns the Shipment or error',
+        "fields":       [
+                            {field: 'username', type: 'String', required: true, requirement: 'Must be a valid turner ldap username', description: 'The username of authenticated user'},
+                            {field: 'token',    type: 'String', required: true, requirement: 'Must be a valid token for username authenticated against http://auth.services.dmtio.net', description: 'The token of authenticated user'}
+                        ]
+    },
+    {
+        "path":         '/v1/envVar/search',
+        "type":         'get',
+        "function":     requestHandlers.searchEnvVars,
+        "description":  'Returns a shipment environment, that contains the envVar name and value',
+        "fields":       []
+    },
+    {
+        "path":         '/v1/logs/shipment/:Shipment/environment/:Environment',
+        "type":         'get',
+        "function":     requestHandlers.getShipmentEnvironmentLogs,
+        "description":  'Returns the changes for a shipment and environment pair.',
+        "fields":       []
+    },
+    {
+        "path":         '/v1/logs/shipment/:Shipment',
+        "type":         'get',
+        "function":     requestHandlers.getShipmentLogs,
+        "description":  'Returns all changes for a shipment. Same as searching /v1/logs/shipment/:Shipment/environment/parent',
+        "fields":       []
+    }
+];
 
 genE.endpoints.forEach(function (i) {
   var r = {path: '/v1' + i.path, type: i.type, description: i.description};

--- a/endpoints/genEndpointsFromMongoose.js
+++ b/endpoints/genEndpointsFromMongoose.js
@@ -4,7 +4,7 @@ let plural   = require('pluralize').plural,
     m        = require('../mongoose/mongoose'),
     models   = require('../models/models'),
     documentToObject = require('../lib/documentToObject'),
-    jsondiff = require('jsondiffpatch'),
+    saveLog  = require('../lib/saveLog').save,
     nils     = ['',null];
 
 module.exports = function(){
@@ -408,35 +408,4 @@ function update(f,r,updateObj,callBack, auth) {
       });
     }
   });
-}
-
-/**
-*  saveLog
-*  @param: jsonA {Object|MongooseDocObject}
-*  @param: jsonB {Object|MongooseDocObject}
-*
-*  take in two different json objects and save a log with the difference between the two.
-*  Also save, who made the change and when. This can later be queried by shipment + environment pair.
-*  If there is no environment, then we know that we are saving against the parent shipment, and hence we
-*  are naming the environment parent.
-*
-*  We are doing a stringify and a parse on each json object passed in. This is because we can either pass in a
-*  raw json object or a mongoose document object.
-*/
-function saveLog(jsonA, jsonB, auth) {
-    let diff = jsondiff.diff(JSON.parse(JSON.stringify(jsonA)), JSON.parse(JSON.stringify(jsonB))) || {};
-    delete diff._id;
-    delete diff.__v;
-    delete diff._parentId;
-    diff = JSON.stringify(diff);
-    auth = auth || {};
-    let log = {
-      shipment: auth.shipment,
-      environment: auth.environment || 'parent',
-      user: auth.username,
-      updated: Math.floor(Date.now()),
-      diff: diff
-    };
-    let logDoc = new m.Logs(log);
-    logDoc.save();
 }

--- a/lib/requestHandlers.js
+++ b/lib/requestHandlers.js
@@ -2,6 +2,7 @@
 
 const auth = require('./auth'),
       schemas  = require('../models/models'),
+      helpers  = require('../models/helpers'),
       documentToObject = require('./documentToObject');
 
 var m = {},
@@ -407,4 +408,53 @@ function obfuscate(obj, isAuthed) {
     }
 
     return obj;
+}
+
+function sendError(code, message, error, response) {
+    console.error(message);
+    if (error) console.error('ERROR: %j', error);
+    response.status(code);
+    response.json({error: message});
+}
+
+e.rollBuildToken = (req, res) => {
+    let shipment = req.params.Shipment,
+        environment = req.params.name;
+
+    auth.checkToken(req.body, (validUser, type) => {
+        if (validUser && type !== 'service') {
+            m.Shipment.findOne({name: shipment}).select({group: 1}).exec((err, shipmentDoc) => {
+                if (err) {
+                    sendError(500, `Unable to retrieve Shipment ${shipment}`, err, res)
+                } else {
+                    auth.checkGroup({ username: req.body.username, group: shipmentDoc.group }, isAuthed => {
+                        if (isAuthed) {
+                            // Full authed
+                            m.Environment.findOne({name: environment, _parentId: `/Shipment_${shipment}`}).exec((err, envDoc) => {
+                                if (err) {
+                                    sendError(500, `Unable to retrieve Environment ${environment} for Shipment ${shipment}`, err, res);
+                                } else {
+                                    envDoc.buildToken = helpers.generateToken();
+                                    envDoc.save((err, saveResult) => {
+                                        if (err) {
+                                            sendError(500, `Unable to update buildToken due to interal error on Shipment ${shipment} Environment ${environment}`, err, msg);
+                                        } else {
+                                            res.json(documentToObject(saveResult));
+                                        }
+                                    });
+                                }
+                            });
+                        }
+                        else {
+                            sendError(403, `Not authorized to change build token for this Shipment ${shipment} environment ${environment}`, null, res);
+                        }
+                    });
+                }
+            });
+        } else if (type === 'service') {
+            sendError(403, 'Service accounts are not allowed to update build tokens', null, res);
+        } else {
+            sendError(401, 'Authorization failure while rolling build token', null, res);
+        }
+    });
 }

--- a/lib/requestHandlers.js
+++ b/lib/requestHandlers.js
@@ -3,6 +3,7 @@
 const auth = require('./auth'),
       schemas  = require('../models/models'),
       helpers  = require('../models/helpers'),
+      saveLog  = require('./saveLog').save,
       documentToObject = require('./documentToObject');
 
 var m = {},
@@ -439,6 +440,12 @@ e.rollBuildToken = (req, res) => {
                                         if (err) {
                                             sendError(500, `Unable to update buildToken due to interal error on Shipment ${shipment} Environment ${environment}`, err, msg);
                                         } else {
+                                            saveLog({buildToken: '**previous**'}, {buildToken: '**current**'}, {
+                                                shipment:    shipment,
+                                                environment: environment,
+                                                username:    req.body.username
+                                            });
+
                                             res.json(documentToObject(saveResult));
                                         }
                                     });

--- a/lib/saveLog.js
+++ b/lib/saveLog.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const jsondiff = require('jsondiffpatch'),
+    mongoose   = require('../mongoose/mongoose');
+
+/**
+*  saveLog
+*  @param: jsonA {Object|MongooseDocObject}
+*  @param: jsonB {Object|MongooseDocObject}
+*
+*  take in two different json objects and save a log with the difference between the two.
+*  Also save, who made the change and when. This can later be queried by shipment + environment pair.
+*  If there is no environment, then we know that we are saving against the parent shipment, and hence we
+*  are naming the environment parent.
+*
+*  We are doing a stringify and a parse on each json object passed in. This is because we can either pass in a
+*  raw json object or a mongoose document object.
+*/
+function saveLog(jsonA, jsonB, auth) {
+    let diff = jsondiff.diff(JSON.parse(JSON.stringify(jsonA)), JSON.parse(JSON.stringify(jsonB))) || {};
+    delete diff._id;
+    delete diff.__v;
+    delete diff._parentId;
+    diff = JSON.stringify(diff);
+    auth = auth || {};
+    let log = {
+      shipment: auth.shipment,
+      environment: auth.environment || 'parent',
+      user: auth.username,
+      updated: Math.floor(Date.now()),
+      diff: diff
+    };
+    let logDoc = new mongoose.Logs(log);
+    logDoc.save();
+}
+
+module.exports = {
+    save: saveLog
+};


### PR DESCRIPTION
This is a simple endpoint that will change (or roll) the build token. 

`PUT /v1/shipment/:Shipment/environment/:name`

I moved the `saveLog` function out to a sub-module to make it easier to reuse that code.

This will close out [Harbor issue 12](https://github.com/turnerlabs/harbor/issues/12).