### PR TITLE
Boolean to enable session affinity when needed (websockets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,13 @@ enable_proxy_protocol
                scheme (only applies to TCP ELBs), defaults false
 - requirement: must be a valid boolean
 
+enable_session_affinity
+- type:        Boolean
+- required:    false
+- description: Boolean, whether we should set up session affinity, needed for websockets
+               (ALB or TCP ELBs), defaults false
+- requirement: must be a valid boolean
+
 private_key
 - type:        String
 - required:    false
@@ -832,6 +839,13 @@ enable_proxy_protocol
 - required:    false
 - description: Boolean, if ELB should forward client IP information via Proxy Protocol
                scheme (only applies to TCP ELBs), defaults false
+- requirement: must be a valid boolean
+
+enable_session_affinity
+- type:        Boolean
+- required:    false
+- description: Boolean, whether we should set up session affinity, needed for websockets
+               (ALB or TCP ELBs), defaults false
 - requirement: must be a valid boolean
 
 private_key

--- a/models/models.js
+++ b/models/models.js
@@ -212,6 +212,17 @@ schema.port = {
       description: 'Boolean, if ELB should forward client IP information via Proxy Protocol scheme (only applies to TCP ELBs), defaults false',
       requirement: 'must be a valid boolean'
   },
+  enable_session_affinity: {
+      type: Boolean,
+      unique: false,
+      create: true,
+      update: true,
+      required: false,
+      default: false,
+      test: helpers.isBoolean,
+      description: 'Boolean, whether we should set up session affinity, needed for websockets (ALB or TCP ELBs), defaults false',
+      requirement: 'must be a valid boolean'
+  },
   private_key: {
     type: String,
     unique: false,


### PR DESCRIPTION
Allows multiple socket.io replicas to work together behind either an AWS ALB or ELB TCP VIP.  Not perfect, but works well enough for now.