### PR TITLE
Update Mongo Error Configurations

### DIFF
--- a/mongoose/mongoose.js
+++ b/mongoose/mongoose.js
@@ -13,13 +13,14 @@ config.mongodb = {
       w: 1,
       socketOptions: {
         keepAlive: 120,
-        connectTimeoutMS: 30000
+        connectTimeoutMS: 10000
       }
     },
     server: {
+      poolSize: 25,
       socketOptions: {
         keepAlive: 120,
-        connectTimeoutMS: 30000
+        connectTimeoutMS: 10000
       },
       auto_reconnect: true
     }
@@ -45,4 +46,29 @@ Object.keys(schemas).forEach(function(schema) {
   schemas[schema].indexes.forEach(function(ind) {
     tempSchema.index(ind.fields,{unique: ind.unique});
   });
+});
+
+
+// set listeners on mongodb to let us know what is going on with MongoDB
+e.DB.on('connecting', function() {
+  console.log('connecting to MongoDB...');
+});
+e.DB.on('error', function(error) {
+  console.error('Error in MongoDb connection: ' + error);
+  mongoose.connection.close();
+});
+e.DB.on('connected', function() {
+  mongoose.connection.readyState = 1;
+  console.log('MongoDB connected!');
+});
+e.DB.once('open', function() {
+  console.log('MongoDB connection opened!');
+});
+e.DB.on('reconnected', function () {
+  mongoose.connection.readyState = 1;
+  console.log('MongoDB reconnected!');
+});
+e.DB.on('disconnected', function() {
+  console.log('MongoDB disconnected!');
+  mongoose.connection.readyState = 0;
 });

--- a/server.js
+++ b/server.js
@@ -73,9 +73,8 @@ let server = app.listen(myPort, function () {
 process.on('SIGTERM', function onSigterm () {
   console.info('ERROR: Got SIGTERM. Graceful shutdown start', new Date().toISOString())
 
-  // Wait a little bit to give enough time for Kubernetes readiness probe to fail
-  // (we are not ready to serve more traffic)
-  // Don't worry livenessProbe won't kill it until (failureThreshold: 3) => 30s
+  // If we get SIGTERM, then k8s is about to kill us. We should tell our server to close down. This will
+  // stopy any new connections from coming in, and will all any open connections time to finish.
   server.close(function () {
     process.exit(0);
   });

--- a/server.js
+++ b/server.js
@@ -75,7 +75,7 @@ process.on('SIGTERM', function onSigterm () {
   console.info('ERROR: Got SIGTERM. Graceful shutdown start', new Date().toISOString())
 
   // If we get SIGTERM, then k8s is about to kill us. We should tell our server to close down. This will
-  // stopy any new connections from coming in, and will all any open connections time to finish.
+  // stop any new connections from coming in, and give open connections time to finish.
   server.close(function () {
     process.exit(0);
   });

--- a/server.js
+++ b/server.js
@@ -10,7 +10,8 @@ let express         = require('express'),
 
 let endPoints = {get:[],post:[],put:[],delete:[]},
     myPort = process.env.PORT || 6055,
-    healthcheck = process.env.HEALTHCHECK || '/_hc';
+    healthcheck = process.env.HEALTHCHECK || '/_hc',
+    ALLOWED_RETRIES = process.env.ALLOWED_RETRIES || 5;
 
 let app = express();
 let retriedConnection = 0;
@@ -44,7 +45,7 @@ app.get(healthcheck, (req, res, next) => {
       retriedConnection = 0;
       res.send('OK Version: ' + appVersion);
   } else {
-      if (retriedConnection > 30) {
+      if (retriedConnection > ALLOWED_RETRIES) {
           console.error('ERROR: Mongoose Connection Is Broken');
           res.status(500).send('ERROR: Mongoose Connection Is Broken');
       } else {


### PR DESCRIPTION
* change timeout to 10 seconds
* add logic in place to fail gracefully on SIGTERM
* add logs to let us know more about what is going on with Mongo
* give the application at least 30 healthchecks before it actually fails, instead of 3