### PR TITLE
Lighten up audit and Add Some extra info

### DIFF
--- a/endpoints/endpoints.js
+++ b/endpoints/endpoints.js
@@ -118,12 +118,12 @@ genE.endpoints.forEach(function (i) {
                 environment: req.params.Environment
             };
             authObject.environment = req.params.Environment;
-            if (!req.body.type || req.body.type === 'hidden' || req.body.private_key) {
+            if (req.body.hidden === true || req.body.type === 'hidden' || req.body.private_key) {
                 authObject.hidden = true;
-            } else if (req.body.type === 'basic' || req.body.type === 'discover') {
+            } else if (req.body.type === 'basic' || req.body.type === 'discover' || req.body.hidden === false) {
                 authObject.hidden = false;
             }
-            console.log(JSON.stringify(logObj));
+            authObject.name = req.params.Port || req.params.Container || req.params.Provider || req.params.Environment || req.params.Shipment
             doer(i,r,req,res,authObject);
           }
         });

--- a/lib/requestHandlers.js
+++ b/lib/requestHandlers.js
@@ -104,7 +104,7 @@ function continueLogs(req, res, params, isAuthZed) {
       let new_logs = logs.map((log) => {
         if (!isAuthZed) {
             // only if specified for user friendlyness.
-            if (!log.hidden || log.hidden === true) {
+            if (log.hidden === undefined || log.hidden === true) {
                 log.diff = "***"
             }
         }
@@ -115,6 +115,8 @@ function continueLogs(req, res, params, isAuthZed) {
           user: log.user,
           updated: log.updated,
           timestamp: log.timestamp,
+          name: log.name,
+          hidden: log.hidden,
           diff: log.diff
         };
       });
@@ -484,6 +486,7 @@ e.rollBuildToken = (req, res) => {
                                             saveLog({buildToken: '**previous**'}, {buildToken: '**current**'}, {
                                                 shipment:    shipment,
                                                 environment: environment,
+                                                name: environment,
                                                 username:    req.body.username,
                                                 hidden: true
                                             });

--- a/lib/saveLog.js
+++ b/lib/saveLog.js
@@ -27,6 +27,7 @@ function saveLog(jsonA, jsonB, auth) {
       shipment: auth.shipment,
       environment: auth.environment || 'parent',
       user: auth.username,
+      name: auth.name,
       hidden: auth.hidden,
       updated: Math.floor(Date.now()),
       diff: diff

--- a/models/models.js
+++ b/models/models.js
@@ -393,6 +393,16 @@ schema.logs = {
     description: "The difference, stored as a JSON string.",
     requirement: "Must be a valid string."
   },
+  name: {
+    type: String,
+    unique: false,
+    create: true,
+    update: false,
+    required: false,
+    test: helpers.isString,
+    description: "The type of object being changed.",
+    requirement: "Must be a valid string."
+  },
   user: {
     type: String,
     unique: false,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "express": "4.13.0",
     "jsondiffpatch": "0.1.43",
     "mongoose": "4.3.4",
+    "morgan": "^1.8.1",
     "pluralize": "1.2.1",
     "randomstring": "1.1.3",
     "request": "2.61.0"

--- a/server.js
+++ b/server.js
@@ -6,7 +6,8 @@ let express         = require('express'),
     genEndpoints    = require('./endpoints/endpoints'),
     appVersion      = require('./package.json').version,
     renderEndPoints = require('./endpoints/render'),
-    mongoose        = require('mongoose');
+    mongoose        = require('mongoose'),
+    morgan = require('morgan');
 
 let endPoints = {get:[],post:[],put:[],delete:[]},
     myPort = process.env.PORT || 6055,
@@ -16,6 +17,7 @@ let app = express();
 
 app.use(bodyParser.json());
 app.use(cors());
+app.use(morgan('tiny'));
 app.use(function (req, res, next) {
     req.body.username = null
     req.body.username = req.headers['x-username'] || '';

--- a/server.js
+++ b/server.js
@@ -17,7 +17,6 @@ let app = express();
 
 app.use(bodyParser.json());
 app.use(cors());
-app.use(morgan('tiny'));
 app.use(function (req, res, next) {
     req.body.username = null
     req.body.username = req.headers['x-username'] || '';
@@ -49,6 +48,8 @@ app.get(healthcheck, (req, res, next) => {
       res.status(500).send(msg);
   }
 });
+
+app.use(morgan('tiny'));
 
 genEndpoints.forEach(function(i) {
   app[i.type](i.path,i.function);


### PR DESCRIPTION
* adding name to audit logs, so we know where a change came from. Ie if I edited a Port, we will now know which Port was update. Currently it just shows the values that have been changed, and not what object they were changed on.
* adding morgan as a logger, and removing uneeded logs, now that we have audit trail
* fixed bug that redacts everything, which makes api still usable without authenticated GETs. This will help usability everywhere. 