### PR TITLE
Opt Out Monitoring

### DIFF
--- a/models/models.js
+++ b/models/models.js
@@ -310,6 +310,17 @@ schema.environment = {
     requirement: "Must be base64 encoded and be a valid docker config file",
     auth: true
   },
+  enableMonitoring: {
+    type: Boolean,
+    unique: false,
+    create: true,
+    update: true,
+    required: false,
+    default: true,
+    test: helpers.isBoolean,
+    description: 'Boolean, if true then monitoring of this Shipment Environment will be setup.',
+    requirement: 'must be a valid boolean'
+  },
   envVars: ['envVar'],
   containers: ['container'],
   providers: ['provider']


### PR DESCRIPTION
ShipIt now supports opting-out of monitoring. This change is backwards compatible. When deployed all current Shipments, and any new Shipments, will have `"enableMonitoring": true`. 

This PR is part of a series of three changes (Trigger and UI are the others). This PR should be deployed first.