### PR TITLE
fix(auth): actually check the users groups

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -26,10 +26,24 @@ function check(uri, obj, callback, method) {
             // if the user is not authzed then, we should check to see if the method is GET and if they have
             // READ_ONLY access
             if (method && body.success === false && method.toLowerCase() === 'get') {
-              body.success = READ_ONLY_GROUPS.indexOf(obj.groupname) !== -1;
-            }
+              request({uri: `https://argonaut.turner.com/getUserGroups/${obj.username}`, method: 'GET'}, (err, resp, body) => {
+                  if (err) {
+                      callback(false);
+                      return;
+                  }
 
-            callback(body.success, typeof body.type !== 'undefined' ? body.type : null);
+                  var groups = body.groups_adminned.concat(body.groups_in);
+                  groups.forEach((group) => {
+                    if (READ_ONLY_GROUPS.indexOf(group) !== -1) {
+                      body.success = true;
+                    }
+                  });
+
+                  callback(body.success, typeof body.type !== 'undefined' ? body.type : null);
+              });
+            } else {
+              callback(body.success, typeof body.type !== 'undefined' ? body.type : null);
+            }
         } else {
             callback(false);
         }


### PR DESCRIPTION
Final PR for read only feature. Before we were not actually checking the groups the user was in. We needed to make another API call to argonauts to get the users groups. This PR works, and I have fully tested it with a member of iso already. 