### PR TITLE
Healthcheck timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/turnerlabs/shipit-api/tree/master.svg?style=shield)](https://circleci.com/gh/turnerlabs/shipit-api/tree/master)
 
-API Version `2.5.0`
+API Version `2.5.1`
 
 [Additional documentation](http://blog.harbor.inturner.io/docs/shipit/)
 
@@ -364,6 +364,12 @@ ssl_management_type
 - required:    false
 - description: SSL management type.
 - requirement: Must be a valid SSL Management type (iam or acm)
+
+healthcheck_timeout
+- type:        Number
+- required:    false
+- description: The timeout value for the healthcheck for container monitoring
+- requirement: Must be 0 or positive Integer
 
 ```
 
@@ -881,6 +887,12 @@ ssl_management_type
 - required:    false
 - description: SSL management type.
 - requirement: Must be a valid SSL Management type (iam or acm)
+
+healthcheck_timeout
+- type:        Number
+- required:    false
+- description: The timeout value for the healthcheck for container monitoring
+- requirement: Must be 0 or positive Integer
 
 ```
 

--- a/models/models.js
+++ b/models/models.js
@@ -276,7 +276,7 @@ schema.port = {
     create: true,
     update: true,
     required: false,
-    default: 1,
+    default: 3,
     test: helpers.isValidInteger,
     description: "The timeout value for the healthcheck for container monitoring",
     requirement: "Must be 0 or positive Integer"

--- a/models/models.js
+++ b/models/models.js
@@ -269,6 +269,17 @@ schema.port = {
     test: helpers.isValidSslManager,
     description: 'SSL management type.',
     requirement: 'Must be a valid SSL Management type (iam or acm)'
+  },
+  healthcheck_timeout: {
+    type: Number,
+    unique: false,
+    create: true,
+    update: true,
+    required: false,
+    default: 1,
+    test: helpers.isValidInteger,
+    description: "The timeout value for the healthcheck for container monitoring",
+    requirement: "Must be 0 or positive Integer"
   }
 }
 


### PR DESCRIPTION
Allows one to override the 'default' healthcheck time.  Also increase the default to 3 seconds rather than 1 second, which seems pretty aggressive for any deep healthcheck.