### PR TITLE
fix(migration): allow buildToken to be passed in for migration

### DIFF
--- a/routes/shipment.js
+++ b/routes/shipment.js
@@ -244,10 +244,12 @@ function bulk(req, res, next) {
                     environment.composite = baseComposite;
                     environment.shipmentId = `${shipment.name}`;
 
+                    // During the migration, we will allow buildToken to be passed in if it exists regardless of
+                    // whether the Shipment is new or not
                     if (originalShipment) {
-                        environment.buildToken = originalShipment.environments[0].buildToken || helpers.generateToken();
+                        environment.buildToken = shipment.environments[0].buildToken || originalShipment.environments[0].buildToken || helpers.generateToken();
                     } else {
-                        environment.buildToken = helpers.generateToken();
+                        environment.buildToken = shipment.environments[0].buildToken || helpers.generateToken();
                     }
 
                     let promise = models.Environment.upsert(environment, {

--- a/test/60.bulk.js
+++ b/test/60.bulk.js
@@ -474,8 +474,8 @@ describe('Bulk', function () {
                     expect(body.parentShipment.group, 'body.parentShipment.group').to.equal(data.parentShipment.group);
                     expect(compare(body.parentShipment.envVars, data.parentShipment.envVars), 'compare(body.parentShipment.envVars, data.parentShipment.envVars)').to.be.true;
                     expect(body.buildToken, 'body.buildToken').to.not.be.null;
-                    expect(body.buildToken, 'body.buildToken').to.have.lengthOf(50);
-                    expect(body.buildToken, 'body.buildToken').to.not.equal(data.buildToken);
+                    expect(body.buildToken, 'body.buildToken').to.have.lengthOf(5);
+                    expect(body.buildToken, 'body.buildToken').to.equal(data.buildToken);
 
                     done();
                 });
@@ -503,7 +503,7 @@ describe('Bulk', function () {
                     expect(body.parentShipment.group, 'body.parentShipment.group').to.equal(data.parentShipment.group);
                     expect(compare(body.parentShipment.envVars, data.parentShipment.envVars), 'compare(body.parentShipment.envVars, data.parentShipment.envVars)').to.be.true;
                     expect(body.buildToken, 'body.buildToken').to.not.be.null;
-                    expect(body.buildToken, 'body.buildToken').to.have.lengthOf(50);
+                    expect(body.buildToken, 'body.buildToken').to.have.lengthOf(5);
 
                     done();
                 });


### PR DESCRIPTION
For the migration we need to allow the current `buildToken` to be migrated.