### PR TITLE
fix(log): make audit log api faster

### DIFF
--- a/Dockerfile_local
+++ b/Dockerfile_local
@@ -1,0 +1,5 @@
+From node:6.10.3
+WORKDIR /opt/shipit-api
+ADD . .
+RUN npm install
+CMD ["./bin/www"]

--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ app.use(cors());
 
 app.get('/_hc', middleware.health);
 
-app.use(morgan('common'));
+app.use(morgan('short'));
 
 const routes = require('./routes'),
     shipment = require('./routes/shipment'),

--- a/models/log.js
+++ b/models/log.js
@@ -17,10 +17,6 @@ module.exports = (sequelize, DataTypes) => {
                 type: DataTypes.TEXT,
                 set(val) {
                     this.setDataValue('diff', val ? crypto.encrypt(val.toString()) : val);
-                },
-                get() {
-                    let val = this.getDataValue('diff');
-                    return val ? crypto.decrypt(val) : val;
                 }
             },
             user: {


### PR DESCRIPTION
* this bypasses sequalize's GET method, and does the decrypt in raw js. It looks to be much faster. I am testing with a shipment that has 1000's of changes and there is no perf issue at all.
* also added the ability to hide if the user is not authed. We do not want to show logs if the user is not authed. This breaks from what the API used to do. It would check if the value is hidden or not, but it seems like everything is hidden: false, so for now just hiding everything, as it's leaking values.