### PR TITLE
fix(routes): get the trigger logs from DB

### DIFF
--- a/routes/log.js
+++ b/routes/log.js
@@ -78,7 +78,7 @@ function post(req, res, next) {
  * @returns {Object} The where clause object
  */
 function getWhereClause(params) {
-    let where = {$and: {shipment: params.shipment}};
+    let where = {$and: {$or: {shipment: params.shipment, name: params.shipment}}};
 
     if (params.shipment && params.environment) {
         where.$and.environment = params.environment;


### PR DESCRIPTION
closes #26 

We were just not making the correct query to get the trigger logs. This will start pulling in all the logs that are sent via Triggers.