### PR TITLE
fix(auth): should skip authz on certain paths

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,10 @@ const pkg = require('../package.json'),
     handler = require('../lib/handler'),
     models = require('../models');
 
+const noAuthzPaths = [
+    '/v1/shipments'
+];
+
 let showErrorStack = process.env.SHOW_ERROR_STACK || true;
 
 let can = {
@@ -157,6 +161,11 @@ function setGroups(req, res, next) {
 
     if (req.body.parentShipment) {
         name = req.body.parentShipment.name;
+    }
+
+    // only set groups if we can have a group
+    if (req.method === 'GET' && noAuthzPaths.includes(req.path)) {
+        return next();
     }
 
     // only get groups if we are authenticated

--- a/test/10.shipments.js
+++ b/test/10.shipments.js
@@ -162,6 +162,42 @@ describe('Shipments', function () {
                 });
         });
 
+        it('should return a list of shipments', function (done) {
+            request(server)
+                .get('/v1/shipments')
+                .expect('Content-Type', /json/)
+                .expect(200, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    let data = res.body;
+
+                    expect(data).to.have.lengthOf(1);
+
+                    done();
+                });
+        });
+
+        it('should return a list of shipments while authenticated', function (done) {
+            request(server)
+                .get('/v1/shipments')
+                .set('x-username', authUser)
+                .set('x-token', authToken)
+                .expect('Content-Type', /json/)
+                .expect(200, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    let data = res.body;
+
+                    expect(data).to.have.lengthOf(1);
+
+                    done();
+                });
+        });
+
         it('should error when fetching non-existent Shipment', function (done) {
             request(server)
                 .get('/v1/shipment/not-real')


### PR DESCRIPTION
Added tests for using authenticated GETs on Shipment list call.