### PR TITLE
Healthcheck interval

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -358,6 +358,12 @@ healthcheck_timeout
 - description: The timeout value for the healthcheck for container monitoring
 - requirement: Must be 0 or positive Integer
 
+healthcheck_interval
+- type:        Number
+- required:    false
+- description: The interval value for the healthcheck for container monitoring
+- requirement: Must be 0 or positive Integer
+
 ```
 
 
@@ -873,6 +879,12 @@ healthcheck_timeout
 - type:        Number
 - required:    false
 - description: The timeout value for the healthcheck for container monitoring
+- requirement: Must be 0 or positive Integer
+
+healthcheck_interval
+- type:        Number
+- required:    false
+- description: The interval value for the healthcheck for container monitoring
 - requirement: Must be 0 or positive Integer
 
 ```

--- a/MODELS.md
+++ b/MODELS.md
@@ -71,7 +71,7 @@ There are several types of objects that are related to a Shipment in ShipIt.
     "enable_proxy_protocol":  "Boolean. Should the load balancer forward client IP information via Proxy Protocol scheme (only applies when protocol is tcp); defaults false.",
     "ssl_arn":                "String. ARN for an AWS ACM SSL Certificate or manually upload IAM server certificate",
     "ssl_management_type":    "String. SSL management type, currently supporting 'iam' or 'acm'",
-    "healthcheck_timeout":    "Integer. Number of seconds the health check should wait before considering the service to have timed out. Defaults to 3.",
+    "healthcheck_timeout":    "Integer. Number of seconds the health check should wait before considering the service to have timed out. Defaults to 1.",
     "healthcheck_interval":    "Integer. Number of seconds the health check should wait between healthcheck runs. Defaults to 10.",
     "lbtype":                 "String. Type of load balancer to create. Defaults to 'default'."
 }

--- a/MODELS.md
+++ b/MODELS.md
@@ -71,7 +71,8 @@ There are several types of objects that are related to a Shipment in ShipIt.
     "enable_proxy_protocol":  "Boolean. Should the load balancer forward client IP information via Proxy Protocol scheme (only applies when protocol is tcp); defaults false.",
     "ssl_arn":                "String. ARN for an AWS ACM SSL Certificate or manually upload IAM server certificate",
     "ssl_management_type":    "String. SSL management type, currently supporting 'iam' or 'acm'",
-    "healthcheck_timeout":    "Integer. Number of seconds the health check should wait before considering the service to have timed out. Defaults to 1.",
+    "healthcheck_timeout":    "Integer. Number of seconds the health check should wait before considering the service to have timed out. Defaults to 3.",
+    "healthcheck_interval":    "Integer. Number of seconds the health check should wait between healthcheck runs. Defaults to 10.",
     "lbtype":                 "String. Type of load balancer to create. Defaults to 'default'."
 }
 ```

--- a/migrations/20170906161500-healthcheck_interval.js
+++ b/migrations/20170906161500-healthcheck_interval.js
@@ -1,0 +1,53 @@
+module.exports = {
+    up: function (queryInterface, DataTypes) {
+        let changes = [];
+
+        // healthcheck_interval
+        changes.push(
+            queryInterface.addColumn(
+                'Ports',
+                'healthcheck_interval',
+                {
+                    type: DataTypes.INTEGER,
+                    field: "healthcheck_interval",
+                    validate: {
+                        min: 1,
+                        max: 3600
+                    },
+                    defaultValue: 10,
+                    get() {
+                        return this.getDataValue('healthcheck_interval') || this.getDataValue('value');
+                    }
+                }
+            )
+        );
+
+        return Promise.all(changes);
+    },
+
+    down: function (queryInterface, DataTypes) {
+        let changes = [];
+
+        // healthcheck_interval
+        changes.push(
+            queryInterface.addColumn(
+                'Ports',
+                'healthcheck_interval',
+                {
+                    type: DataTypes.INTEGER,
+                    field: "healthcheck_interval",
+                    validate: {
+                        min: 1,
+                        max: 3600
+                    },
+                    defaultValue: 10,
+                    get() {
+                        return this.getDataValue('healthcheck_interval') || this.getDataValue('value');
+                    }
+                }
+            )
+        );
+
+        return Promise.all(changes);
+    }
+};

--- a/migrations/20170906161500-healthcheck_interval.js
+++ b/migrations/20170906161500-healthcheck_interval.js
@@ -2,25 +2,29 @@ module.exports = {
     up: function (queryInterface, DataTypes) {
         let changes = [];
 
-        // healthcheck_interval
-        changes.push(
-            queryInterface.changeColumn(
-                'Ports',
-                'healthcheck_interval',
-                {
-                    type: DataTypes.INTEGER,
-                    field: "healthcheck_interval",
-                    validate: {
-                        min: 1,
-                        max: 3600
-                    },
-                    defaultValue: 10,
-                    get() {
-                        return this.getDataValue('healthcheck_interval') || this.getDataValue('value');
+        queryInterface.describeTable('Ports').then(attributes => {
+          if (!attributes.hasOwnProperty('healthcheck_interval')) {
+            // healthcheck_interval
+            changes.push(
+                queryInterface.addColumn(
+                    'Ports',
+                    'healthcheck_interval',
+                    {
+                        type: DataTypes.INTEGER,
+                        field: "healthcheck_interval",
+                        validate: {
+                            min: 1,
+                            max: 3600
+                        },
+                        defaultValue: 10,
+                        get() {
+                            return this.getDataValue('healthcheck_interval') || this.getDataValue('value');
+                        }
                     }
-                }
-            )
-        );
+                )
+            );
+          }
+        });
 
         return Promise.all(changes);
     },
@@ -30,7 +34,7 @@ module.exports = {
 
         // healthcheck_interval
         changes.push(
-            queryInterface.changeColumn(
+            queryInterface.addColumn(
                 'Ports',
                 'healthcheck_interval',
                 {

--- a/migrations/20170906161500-healthcheck_interval.js
+++ b/migrations/20170906161500-healthcheck_interval.js
@@ -4,7 +4,7 @@ module.exports = {
 
         // healthcheck_interval
         changes.push(
-            queryInterface.addColumn(
+            queryInterface.changeColumn(
                 'Ports',
                 'healthcheck_interval',
                 {
@@ -30,7 +30,7 @@ module.exports = {
 
         // healthcheck_interval
         changes.push(
-            queryInterface.addColumn(
+            queryInterface.changeColumn(
                 'Ports',
                 'healthcheck_interval',
                 {

--- a/models/port.js
+++ b/models/port.js
@@ -180,7 +180,7 @@ module.exports = (sequelize, DataTypes) => {
             },
             healthcheck_timeout: {
                 type: DataTypes.INTEGER,
-                defaultValue: 3,
+                defaultValue: 1,
                 field: "healthcheck_timeout",
                 validate: {
                     min: 1,

--- a/models/port.js
+++ b/models/port.js
@@ -180,8 +180,17 @@ module.exports = (sequelize, DataTypes) => {
             },
             healthcheck_timeout: {
                 type: DataTypes.INTEGER,
-                defaultValue: 1,
+                defaultValue: 3,
                 field: "healthcheck_timeout",
+                validate: {
+                    min: 1,
+                    max: 3600
+                }
+            },
+            healthcheck_interval: {
+                type: DataTypes.INTEGER,
+                defaultValue: 10,
+                field: "healthcheck_interval",
                 validate: {
                     min: 1,
                     max: 3600

--- a/test/35.ports.js
+++ b/test/35.ports.js
@@ -66,7 +66,7 @@ describe('Port', function () {
                     let data = res.body,
                         props = [ 'name', 'healthcheck', 'external', 'primary', 'public_vip', 'public_port', 'enable_proxy_protocol',
                             'ssl_management_type', 'ssl_arn', 'private_key', 'public_key_certificate', 'certificate_chain',
-                            'healthcheck_timeout', 'lbtype' ],
+                            'healthcheck_timeout', 'healthcheck_interval', 'lbtype' ],
                         excludes = ['composite', 'containerId', 'createdAt', 'updatedAt', 'deletedAt'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
@@ -85,7 +85,8 @@ describe('Port', function () {
                     expect(data.private_key, 'data.private_key').to.be.a('string');
                     expect(data.public_key_certificate, 'data.public_key_certificate').to.be.a('string');
                     expect(data.certificate_chain, 'data.certificate_chain').to.be.a('string');
-                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(1);
+                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(3);
+                    expect(data.healthcheck_interval, 'data.healthcheck_interval').to.equal(10);
                     expect(data.lbtype, 'data.lbtype').to.equal('default');
 
                     done();
@@ -117,7 +118,7 @@ describe('Port', function () {
                     let data = res.body,
                         props = [ 'name', 'healthcheck', 'external', 'primary', 'public_vip', 'public_port', 'enable_proxy_protocol',
                             'ssl_management_type', 'ssl_arn', 'private_key', 'public_key_certificate', 'certificate_chain',
-                            'healthcheck_timeout', 'lbtype' ],
+                            'healthcheck_timeout', 'healthcheck_interval', 'lbtype' ],
                         excludes = ['composite', 'containerId', 'createdAt', 'updatedAt', 'deletedAt'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
@@ -137,6 +138,7 @@ describe('Port', function () {
                     expect(data.public_key_certificate, 'data.public_key_certificate').to.be.a('string');
                     expect(data.certificate_chain, 'data.certificate_chain').to.be.a('string');
                     expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(5);
+                    expect(data.healthcheck_interval, 'data.healthcheck_interval').to.equal(10);
                     expect(data.lbtype, 'data.lbtype').to.equal('default');
 
                     done();
@@ -194,7 +196,7 @@ describe('Port', function () {
 
                     let data = res.body,
                         props = [ 'name', 'healthcheck', 'external', 'primary', 'public_vip', 'public_port', 'lbtype',
-                            'enable_proxy_protocol', 'healthcheck_timeout', 'ssl_management_type', 'ssl_arn' ],
+                            'enable_proxy_protocol', 'healthcheck_timeout', 'healthcheck_interval', 'ssl_management_type', 'ssl_arn' ],
                         excludes = ['composite', 'containerId', 'private_key', 'public_key_certificate',
                             'certificate_chain' ];
 
@@ -235,7 +237,7 @@ describe('Port', function () {
 
                     let data = res.body,
                         props = [ 'name', 'healthcheck', 'external', 'primary', 'public_vip', 'public_port', 'lbtype',
-                            'enable_proxy_protocol', 'healthcheck_timeout', 'ssl_management_type', 'ssl_arn' ],
+                            'enable_proxy_protocol', 'healthcheck_timeout', 'healthcheck_interval', 'ssl_management_type', 'ssl_arn' ],
                         excludes = ['composite', 'containerId', 'private_key',
                             'public_key_certificate', 'certificate_chain'];
 
@@ -250,7 +252,8 @@ describe('Port', function () {
                     expect(data.public_vip, 'data.public_vip').to.be.false;
                     expect(data.public_port, 'data.public_port').to.equal(5000);
                     expect(data.enable_proxy_protocol, 'data.enable_proxy_protocol').to.be.false;
-                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(1);
+                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(3);
+                    expect(data.healthcheck_interval, 'data.healthcheck_interval').to.equal(10);
                     expect(data.ssl_arn, 'data.ssl_arn').to.equal('');
                     expect(data.ssl_management_type, 'data.ssl_management_type').to.equal('iam');
                     expect(data.lbtype, 'data.lbtype').to.equal('default');
@@ -271,7 +274,7 @@ describe('Port', function () {
 
                     let data = res.body,
                         props = [ 'name', 'healthcheck', 'external', 'primary', 'public_vip', 'public_port', 'lbtype',
-                            'enable_proxy_protocol', 'healthcheck_timeout', 'ssl_management_type', 'ssl_arn', 'private_key',
+                            'enable_proxy_protocol', 'healthcheck_timeout', 'healthcheck_interval', 'ssl_management_type', 'ssl_arn', 'private_key',
                                 'public_key_certificate', 'certificate_chain' ],
                         excludes = ['composite', 'containerId'];
 
@@ -286,7 +289,8 @@ describe('Port', function () {
                     expect(data.public_vip, 'data.public_vip').to.be.false;
                     expect(data.public_port, 'data.public_port').to.equal(5000);
                     expect(data.enable_proxy_protocol, 'data.enable_proxy_protocol').to.be.false;
-                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(1);
+                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(3);
+                    expect(data.healthcheck_interval, 'data.healthcheck_interval').to.equal(10);
                     expect(data.lbtype, 'data.lbtype').to.equal('default');
 
                     done();

--- a/test/35.ports.js
+++ b/test/35.ports.js
@@ -85,7 +85,7 @@ describe('Port', function () {
                     expect(data.private_key, 'data.private_key').to.be.a('string');
                     expect(data.public_key_certificate, 'data.public_key_certificate').to.be.a('string');
                     expect(data.certificate_chain, 'data.certificate_chain').to.be.a('string');
-                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(3);
+                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(1);
                     expect(data.healthcheck_interval, 'data.healthcheck_interval').to.equal(10);
                     expect(data.lbtype, 'data.lbtype').to.equal('default');
 
@@ -252,7 +252,7 @@ describe('Port', function () {
                     expect(data.public_vip, 'data.public_vip').to.be.false;
                     expect(data.public_port, 'data.public_port').to.equal(5000);
                     expect(data.enable_proxy_protocol, 'data.enable_proxy_protocol').to.be.false;
-                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(3);
+                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(1);
                     expect(data.healthcheck_interval, 'data.healthcheck_interval').to.equal(10);
                     expect(data.ssl_arn, 'data.ssl_arn').to.equal('');
                     expect(data.ssl_management_type, 'data.ssl_management_type').to.equal('iam');
@@ -289,7 +289,7 @@ describe('Port', function () {
                     expect(data.public_vip, 'data.public_vip').to.be.false;
                     expect(data.public_port, 'data.public_port').to.equal(5000);
                     expect(data.enable_proxy_protocol, 'data.enable_proxy_protocol').to.be.false;
-                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(3);
+                    expect(data.healthcheck_timeout, 'data.healthcheck_timeout').to.equal(1);
                     expect(data.healthcheck_interval, 'data.healthcheck_interval').to.equal(10);
                     expect(data.lbtype, 'data.lbtype').to.equal('default');
 

--- a/test/60.bulk.js
+++ b/test/60.bulk.js
@@ -864,7 +864,7 @@ describe('Bulk', function () {
                     expect(body.containers[0].ports[0].public_vip, 'body.containers[0].ports[0].public_vip').to.be.false;
                     expect(body.containers[0].ports[0].enable_proxy_protocol, 'body.containers[0].ports[0].enable_proxy_protocol').to.be.false;
                     expect(body.containers[0].ports[0].ssl_management_type, 'body.containers[0].ports[0].ssl_management_type').to.equal('iam');
-                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(3);
+                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(1);
                     expect(body.containers[0].ports[0].healthcheck_interval, 'body.containers[0].ports[0].healthcheck_interval').to.equal(10);
                     expect(body.containers[0].ports[0].public_port, 'body.containers[0].ports[0].public_port').to.equal(80);
                     expect(body.containers[0].ports[0].value, 'body.containers[0].ports[0].value').to.equal(15080);
@@ -917,7 +917,7 @@ describe('Bulk', function () {
                     expect(body.containers[0].ports[0].public_vip, 'body.containers[0].ports[0].public_vip').to.be.false;
                     expect(body.containers[0].ports[0].enable_proxy_protocol, 'body.containers[0].ports[0].enable_proxy_protocol').to.be.false;
                     expect(body.containers[0].ports[0].ssl_management_type, 'body.containers[0].ports[0].ssl_management_type').to.equal('iam');
-                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(3);
+                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(1);
                     expect(body.containers[0].ports[0].healthcheck_interval, 'body.containers[0].ports[0].healthcheck_interval').to.equal(10);
                     expect(body.containers[0].ports[0].public_port, 'body.containers[0].ports[0].public_port').to.equal(80);
                     expect(body.containers[0].ports[0].value, 'body.containers[0].ports[0].value').to.equal(15080);
@@ -1033,7 +1033,7 @@ describe('Bulk', function () {
                     expect(body.containers[0].ports[0].public_vip, 'body.containers[0].ports[0].public_vip').to.be.false;
                     expect(body.containers[0].ports[0].enable_proxy_protocol, 'body.containers[0].ports[0].enable_proxy_protocol').to.be.false;
                     expect(body.containers[0].ports[0].ssl_management_type, 'body.containers[0].ports[0].ssl_management_type').to.equal('iam');
-                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(3);
+                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(1);
                     expect(body.containers[0].ports[0].healthcheck_interval, 'body.containers[0].ports[0].healthcheck_interval').to.equal(10);
                     expect(body.containers[0].ports[0].public_port, 'body.containers[0].ports[0].public_port').to.equal(80);
                     expect(body.containers[0].ports[0].value, 'body.containers[0].ports[0].value').to.equal(15080);
@@ -1086,7 +1086,7 @@ describe('Bulk', function () {
                     expect(body.containers[0].ports[0].public_vip, 'body.containers[0].ports[0].public_vip').to.be.false;
                     expect(body.containers[0].ports[0].enable_proxy_protocol, 'body.containers[0].ports[0].enable_proxy_protocol').to.be.false;
                     expect(body.containers[0].ports[0].ssl_management_type, 'body.containers[0].ports[0].ssl_management_type').to.equal('iam');
-                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(3);
+                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(1);
                     expect(body.containers[0].ports[0].healthcheck_interval, 'body.containers[0].ports[0].healthcheck_interval').to.equal(10);
                     expect(body.containers[0].ports[0].public_port, 'body.containers[0].ports[0].public_port').to.equal(80);
                     expect(body.containers[0].ports[0].value, 'body.containers[0].ports[0].value').to.equal(15080);

--- a/test/60.bulk.js
+++ b/test/60.bulk.js
@@ -53,7 +53,7 @@ describe('Bulk', function () {
                             parentShipment: ['name', 'group', 'envVars'],
                             container: ['name', 'image', 'envVars', 'ports'],
                             provider: ['name', 'replicas', 'barge', 'envVars'],
-                            port: ['name', 'healthcheck', 'external', 'primary', 'public_vip', 'enable_proxy_protocol', 'healthcheck_timeout'],
+                            port: ['name', 'healthcheck', 'external', 'primary', 'public_vip', 'enable_proxy_protocol', 'healthcheck_timeout', 'healthcheck_interval'],
                             envVar: ['name', 'value', 'type']
                         },
                         excludes = {
@@ -545,7 +545,7 @@ describe('Bulk', function () {
                             container: ['name', 'image', 'envVars', 'ports'],
                             provider: ['name', 'replicas', 'barge', 'envVars'],
                             port: ['name', 'healthcheck', 'external', 'primary', 'public_vip', 'enable_proxy_protocol',
-                                'healthcheck_timeout', 'ssl_management_type', 'ssl_arn'],
+                                'healthcheck_timeout', 'healthcheck_interval', 'ssl_management_type', 'ssl_arn'],
                             envVar: ['name', 'value', 'type']
                         },
                         excludes = {
@@ -624,7 +624,7 @@ describe('Bulk', function () {
                             provider: ['name', 'replicas', 'barge', 'envVars'],
                             port: ['name', 'healthcheck', 'external', 'primary', 'public_vip', 'enable_proxy_protocol',
                                 'ssl_management_type', 'ssl_arn', 'private_key', 'public_key_certificate',
-                                'certificate_chain', 'healthcheck_timeout'],
+                                'certificate_chain', 'healthcheck_timeout', 'healthcheck_interval'],
                             envVar: ['name', 'value', 'type']
                         },
                         excludes = {
@@ -864,7 +864,8 @@ describe('Bulk', function () {
                     expect(body.containers[0].ports[0].public_vip, 'body.containers[0].ports[0].public_vip').to.be.false;
                     expect(body.containers[0].ports[0].enable_proxy_protocol, 'body.containers[0].ports[0].enable_proxy_protocol').to.be.false;
                     expect(body.containers[0].ports[0].ssl_management_type, 'body.containers[0].ports[0].ssl_management_type').to.equal('iam');
-                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(1);
+                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(3);
+                    expect(body.containers[0].ports[0].healthcheck_interval, 'body.containers[0].ports[0].healthcheck_interval').to.equal(10);
                     expect(body.containers[0].ports[0].public_port, 'body.containers[0].ports[0].public_port').to.equal(80);
                     expect(body.containers[0].ports[0].value, 'body.containers[0].ports[0].value').to.equal(15080);
                     expect(body.containers[0].ports[0].name, 'body.containers[0].ports[0].name').to.equal('PORT');
@@ -916,7 +917,8 @@ describe('Bulk', function () {
                     expect(body.containers[0].ports[0].public_vip, 'body.containers[0].ports[0].public_vip').to.be.false;
                     expect(body.containers[0].ports[0].enable_proxy_protocol, 'body.containers[0].ports[0].enable_proxy_protocol').to.be.false;
                     expect(body.containers[0].ports[0].ssl_management_type, 'body.containers[0].ports[0].ssl_management_type').to.equal('iam');
-                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(1);
+                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(3);
+                    expect(body.containers[0].ports[0].healthcheck_interval, 'body.containers[0].ports[0].healthcheck_interval').to.equal(10);
                     expect(body.containers[0].ports[0].public_port, 'body.containers[0].ports[0].public_port').to.equal(80);
                     expect(body.containers[0].ports[0].value, 'body.containers[0].ports[0].value').to.equal(15080);
                     expect(body.containers[0].ports[0].name, 'body.containers[0].ports[0].name').to.equal('PORT');
@@ -1031,7 +1033,8 @@ describe('Bulk', function () {
                     expect(body.containers[0].ports[0].public_vip, 'body.containers[0].ports[0].public_vip').to.be.false;
                     expect(body.containers[0].ports[0].enable_proxy_protocol, 'body.containers[0].ports[0].enable_proxy_protocol').to.be.false;
                     expect(body.containers[0].ports[0].ssl_management_type, 'body.containers[0].ports[0].ssl_management_type').to.equal('iam');
-                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(1);
+                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(3);
+                    expect(body.containers[0].ports[0].healthcheck_interval, 'body.containers[0].ports[0].healthcheck_interval').to.equal(10);
                     expect(body.containers[0].ports[0].public_port, 'body.containers[0].ports[0].public_port').to.equal(80);
                     expect(body.containers[0].ports[0].value, 'body.containers[0].ports[0].value').to.equal(15080);
                     expect(body.containers[0].ports[0].name, 'body.containers[0].ports[0].name').to.equal('PORT');
@@ -1083,7 +1086,8 @@ describe('Bulk', function () {
                     expect(body.containers[0].ports[0].public_vip, 'body.containers[0].ports[0].public_vip').to.be.false;
                     expect(body.containers[0].ports[0].enable_proxy_protocol, 'body.containers[0].ports[0].enable_proxy_protocol').to.be.false;
                     expect(body.containers[0].ports[0].ssl_management_type, 'body.containers[0].ports[0].ssl_management_type').to.equal('iam');
-                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(1);
+                    expect(body.containers[0].ports[0].healthcheck_timeout, 'body.containers[0].ports[0].healthcheck_timeout').to.equal(3);
+                    expect(body.containers[0].ports[0].healthcheck_interval, 'body.containers[0].ports[0].healthcheck_interval').to.equal(10);
                     expect(body.containers[0].ports[0].public_port, 'body.containers[0].ports[0].public_port').to.equal(80);
                     expect(body.containers[0].ports[0].value, 'body.containers[0].ports[0].value').to.equal(15080);
                     expect(body.containers[0].ports[0].name, 'body.containers[0].ports[0].name').to.equal('PORT');

--- a/test/mocks/bulk/5.shipment_container_2ports.json
+++ b/test/mocks/bulk/5.shipment_container_2ports.json
@@ -42,6 +42,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 80,
           "value": 15080,
           "name": "PORT"
@@ -56,6 +57,7 @@
           "ssl_arn": "foobar",
           "ssl_management_type": "acm",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 443,
           "value": 15443,
           "name": "PORT_HTTPS"

--- a/test/mocks/bulk/51.shipment_container_2ports.failure.json
+++ b/test/mocks/bulk/51.shipment_container_2ports.failure.json
@@ -42,6 +42,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 1,
           "public_port": 80,
           "name": "PORT"
         },
@@ -55,6 +56,7 @@
           "ssl_arn": "foobar",
           "ssl_management_type": "acm",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 1,
           "public_port": 443,
           "value": 15443,
           "name": "PORT_HTTPS"

--- a/test/mocks/bulk/6.shipment_2providers_2containers_3ports.json
+++ b/test/mocks/bulk/6.shipment_2providers_2containers_3ports.json
@@ -87,6 +87,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 80,
           "value": 15080,
           "name": "PORT"
@@ -101,6 +102,7 @@
           "ssl_arn": "foobar",
           "ssl_management_type": "acm",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 443,
           "value": 15443,
           "name": "PORT_HTTPS"
@@ -122,6 +124,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "value": 7878,
           "name": "PORT_SIDECAR"
         }

--- a/test/mocks/bulk/61.shipment_2providers_2containers_3ports.failure.json
+++ b/test/mocks/bulk/61.shipment_2providers_2containers_3ports.failure.json
@@ -66,6 +66,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 80,
           "value": 15080,
           "name": "PORT"
@@ -80,6 +81,7 @@
           "ssl_arn": "foobar",
           "ssl_management_type": "acm",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 443,
           "value": 15443,
           "name": "PORT_HTTPS"
@@ -101,6 +103,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "value": 7878,
           "name": "PORT_SIDECAR"
         }

--- a/test/mocks/bulk/7.shipment_provider_2containers_2ports.json
+++ b/test/mocks/bulk/7.shipment_provider_2containers_2ports.json
@@ -50,6 +50,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 80,
           "value": 15080,
           "name": "PORT"
@@ -71,6 +72,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "value": 7878,
           "name": "PORT_SIDECAR"
         }

--- a/test/mocks/bulk/71.shipment_provider_2containers_2ports.failure.json
+++ b/test/mocks/bulk/71.shipment_provider_2containers_2ports.failure.json
@@ -48,6 +48,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 80,
           "value": 15080,
           "name": "PORT"
@@ -69,6 +70,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "value": 7878,
           "name": "PORT_SIDECAR"
         }

--- a/test/mocks/bulk/81.shipment_env.failure.json
+++ b/test/mocks/bulk/81.shipment_env.failure.json
@@ -69,6 +69,7 @@
                     "ssl_arn": "",
                     "ssl_management_type": "iam",
                     "healthcheck_timeout": 1,
+                    "healthcheck_interval": 10,
                     "enable_sticky_sessions": true,
                     "public_port": 80,
                     "value": 3000,

--- a/test/mocks/bulk/9a.shipment.json
+++ b/test/mocks/bulk/9a.shipment.json
@@ -75,6 +75,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "public_port": 80,
           "value": 15080,
           "name": "PORT"

--- a/test/mocks/bulk_shipment.json
+++ b/test/mocks/bulk_shipment.json
@@ -74,6 +74,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "value": 80,
           "name": "PORT"
       },{
@@ -86,6 +87,7 @@
           "ssl_arn": "foooooooooo",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "value": 443,
           "name": "PORT_SSL"
       }]

--- a/test/mocks/bulk_shipment5.json
+++ b/test/mocks/bulk_shipment5.json
@@ -74,6 +74,7 @@
           "ssl_arn": "",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "value": 80,
           "name": "PORT"
       },{
@@ -86,6 +87,7 @@
           "ssl_arn": "foooooooooo",
           "ssl_management_type": "iam",
           "healthcheck_timeout": 1,
+          "healthcheck_interval": 10,
           "value": 443,
           "name": "PORT_SSL"
       }]

--- a/test/mocks/port.json
+++ b/test/mocks/port.json
@@ -8,6 +8,7 @@
   "ssl_arn": "foo",
   "ssl_management_type": "acm",
   "healthcheck_timeout": 5,
+  "healthcheck_interval": 10,
   "public_port": 80,
   "value": 17290,
   "lbtype": "default",


### PR DESCRIPTION
Add a healthcheck_interval field to Ports with a default of 10 seconds to match current kubernetes defaults.  Will allow customers to override this value to decrease the amount of healthchecks their application receives as the cost of how long it takes to remediate a bad healthcheck.