### PR TITLE
Fix log posting authorization

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -50,19 +50,25 @@ module.exports = {
 
     checkBuildToken: (req, token) => {
         return new Promise((resolve, reject) => {
-            let composite;
+            let composite,
+                shipment = req.shipment || req.body.shipment,
+                environment = req.environment || req.body.environment;
 
-            if (req.environment) {
-                composite = `${req.shipment}-${req.environment}`
+            if (environment) {
+                composite = `${shipment}-${environment}`;
             } else {
-                composite = req.shipment
+                composite = shipment;
+            }
+
+            if (!composite) {
+                resolve({success: false});
             }
 
             // Get the shipment
             Env.findOne({ where: { composite: composite } })
                 .then(environment => {
                     if (!environment) {
-                        let err = new Error(`Cannot find ${ship} ${env}!`);
+                        let err = new Error(`Cannot find ${composite}!`);
                         err.statusCode = 404;
                         return reject(err);
                     }

--- a/routes/log.js
+++ b/routes/log.js
@@ -61,12 +61,7 @@ function get(req, res, next) {
  */
 function post(req, res, next) {
     let log = req.body;
-    let authz = req.authorized || null;
     log.name = log.shipment;
-
-    if (!authz) {
-        log.diff = helpers.hideValue();
-    }
 
     models.Log.create(log)
         .then(result => result.toJSON())

--- a/routes/log.js
+++ b/routes/log.js
@@ -3,10 +3,11 @@ const models = require('../models'),
     handler = require('../lib/handler'),
     helpers = require('../lib/helpers'),
     crypto = require('../lib/crypto'),
+    checkAuth = require('.').checkAuth,
     router = require('express').Router();
 
 // Shipment EnvVars
-router.post('/logs', post);
+router.post('/logs', checkAuth, post);
 router.get('/logs/shipment/:shipment/environment/:environment', get);
 router.get('/logs/shipment/:shipment', get);
 
@@ -60,8 +61,12 @@ function get(req, res, next) {
  */
 function post(req, res, next) {
     let log = req.body;
-
+    let authz = req.authorized || null;
     log.name = log.shipment;
+
+    if (!authz) {
+        log.diff = helpers.hideValue();
+    }
 
     models.Log.create(log)
         .then(result => result.toJSON())

--- a/test/70.logs.js
+++ b/test/70.logs.js
@@ -165,5 +165,81 @@ describe('Logs', function () {
                         });
                 });
         });
+
+        it('should accept a new log entry with buildToken', function (done) {
+            // Need to get the buildToken to start
+            let shipment = 'bulk-shipment-app',
+                environment = 'test6';
+
+            request(server)
+                .get(`/v1/shipment/${shipment}/environment/${environment}`)
+                .set('x-username', authUser)
+                .set('x-token', authToken)
+                .expect('Content-Type', /json/)
+                .expect(200, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    let message = {
+                        shipment: shipment,
+                        environment: environment,
+                        hidden: false,
+                        user: 'trigger',
+                        updated: (new Date()).getTime(),
+                        buildToken: res.body.buildToken,
+                        diff: "Message"
+                    };
+
+
+                    request(server)
+                        .post('/v1/logs')
+                        .send(message)
+                        .expect('Content-Type', /json/)
+                        .expect(201, (err, res) => {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            let body = res.body,
+                                props = ['diff', 'id', 'shipment', 'environment', 'hidden', 'user', 'name', 'timestamp'];
+
+                            props.forEach(prop => expect(body).to.have.property(prop));
+
+                            done();
+                        });
+                });
+        });
+
+        it('should not accept a new log entry without a buildToken', function (done) {
+            // Need to get the buildToken to start
+            let shipment = 'bulk-shipment-app',
+                environment = 'test6';
+
+
+                let message = {
+                    shipment: shipment,
+                    environment: environment,
+                    hidden: false,
+                    user: 'trigger',
+                    updated: (new Date()).getTime(),
+                    diff: "Message"
+                };
+
+
+                request(server)
+                    .post('/v1/logs')
+                    .send(message)
+                    .expect('Content-Type', /json/)
+                    .expect(401, (err, res) => {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        expect(res.body.message).to.equal("Authorization failure");
+
+                        done();
+                    });
+        });
     });
 });


### PR DESCRIPTION
* adding ability to post with just a buildtoken on /logs endpoint
* printing errors from the error handler
* add auth to post /logs
* authorize any service token for any request