### PR TITLE
fix(search): add sha value, display on route

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,7 @@
 const models = require('../models'),
     randomStr = require('randomstring').generate,
     jsondiff = require('jsondiffpatch'),
+    crypto = require('./crypto'),
     Promise = require('bluebird');
 
 const self = module.exports = {
@@ -10,10 +11,12 @@ const self = module.exports = {
     updateAuditLog,
     exclude,
     sortByName: (a, b) => a.name > b.name ? 1 : -1,
+    findIndex,
+    prepEnvVar,
     excludes: {
         container: () => ['composite', 'environmentId'],
         environment: _getEnvironmentExcludes,
-        envVar: () => ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId', 'sha_value'],
+        envVar: () => ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId', 'shaValue'],
         port: _getPortExcludes,
         provider: () => ['composite', 'environmentId'],
         shipment: () => ['composite']
@@ -121,6 +124,42 @@ function updateAuditLog(jsonA, jsonB, req) {
 
     return models.Log.create(log);
 }
+
+/**
+ * prepEnvVar - preps an env var to save
+ *
+ * @param {Object} envVar The env var to be prepped
+ *
+ * @return {Object} Prepped env var
+ */
+function prepEnvVar(envVar) {
+    envVar.shaValue = crypto.sha(envVar.value);
+    return envVar;
+}
+
+/**
+ * findIndex - Find the index of an item in an array
+ *
+ * Finds the index of an item in an array of objects whose name
+ * matches the provided name
+ *
+ * @param {Array} arr The array to check
+ * @param {String} name The name to look for in the array
+ *
+ * @return {Number} The index of the matching item or -1 if not found
+ */
+ function findIndex(arr, name) {
+     let idx = -1;
+
+     for (let i = 0, l = arr.length; i < l; i++) {
+         if (arr[i].name === name) {
+             idx = i;
+             break;
+         }
+     }
+
+     return idx;
+ }
 
 /**
  * _getPortExcludes - return array of fields to be excluded in query

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,6 +10,7 @@ const self = module.exports = {
     getWhereClause,
     updateAuditLog,
     exclude,
+    flatten,
     sortByName: (a, b) => a.name > b.name ? 1 : -1,
     findIndex,
     prepEnvVar,
@@ -42,6 +43,26 @@ function exclude(type, auth, obj) {
     });
 
     return obj;
+}
+
+/**
+ * flatten - Flatten an array of objects
+ *
+ * Takes an array of object and flattens any arrays found within
+ * the array into the array.
+ *
+ * @param {Array} items  The array to flatten
+ *
+ * @returns {Array} A flatten array
+ */
+function flatten(items) {
+    return items.reduce((arr, val) => {
+            if (Array.isArray(val)) {
+                return arr.concat(val);
+            }
+            arr.push(val);
+            return arr;
+        }, []);
 }
 
 /**

--- a/lib/mappers.js
+++ b/lib/mappers.js
@@ -70,7 +70,7 @@ module.exports = {
  * @returns {Object} Returns a clean item
  */
 function _removeDebris(item) {
-    let debris = ['composite', 'shipmentId', 'environmentId', 'containerId', 'providerId']
+    let debris = ['composite', 'shipmentId', 'environmentId', 'containerId', 'providerId', 'shaValue']
 
     debris.forEach(p => {
         if (typeof item[p] !== 'undefined') {

--- a/migrations/20171003143700-env-var-sha.js
+++ b/migrations/20171003143700-env-var-sha.js
@@ -1,0 +1,33 @@
+module.exports = {
+    up: (queryInterface, DataTypes) => {
+        let changes = [];
+
+        queryInterface.describeTable('EnvVars').then(attributes => {
+            if (!attributes.hasOwnProperty('shaValue')) {
+                changes.push(
+                    queryInterface.addColumn(
+                        'EnvVars',
+                        'shaValue',
+                        {
+                            type: DataTypes.STRING,
+                            allowNull: true
+                        }
+                    )
+                );
+            }
+        });
+
+        return Promise.all(changes);
+    },
+
+    down: (queryInterface, DataTypes) => {
+        let changes = [];
+
+        // healthcheck_interval
+        changes.push(
+            queryInterface.removeColumn('EnvVars', 'shaValue')
+        );
+
+        return Promise.all(changes);
+    }
+};

--- a/models/envVar.js
+++ b/models/envVar.js
@@ -35,6 +35,10 @@ module.exports = (sequelize, DataTypes) => {
                 validate: {
                     isIn: [['basic', 'discover', 'hidden']]
                 }
+            },
+            shaValue: {
+                type: DataTypes.STRING,
+                allowNull: true
             }
         },
         {

--- a/routes/environment.js
+++ b/routes/environment.js
@@ -52,6 +52,7 @@ function get(req, res, next) {
                               if (!authz && envVar.type === 'hidden') {
                                   envVar.value = helpers.hideValue();
                               }
+                              delete envVar.shaValue;
                               return envVar;
                           },
                           portFieldDel = (port, authz) => {
@@ -67,20 +68,20 @@ function get(req, res, next) {
 
                       if (result.envVars) {
                           result.envVars = result.envVars
-                          .map(envVar => hide(envVar, authz))
-                          .sort(helpers.sortByName);
+                              .map(envVar => hide(envVar, authz))
+                              .sort(helpers.sortByName);
                       }
                       if (result.parentShipment && result.parentShipment.envVars) {
                           result.parentShipment.envVars = result.parentShipment.envVars
-                          .map(envVar => hide(envVar, authz))
-                          .sort(helpers.sortByName);
+                              .map(envVar => hide(envVar, authz))
+                              .sort(helpers.sortByName);
                       }
                       if (result.containers) {
                           result.containers = result.containers.map(container => {
                               if (container.envVars) {
                                   container.envVars = container.envVars
-                                  .map(envVar => hide(envVar, authz))
-                                  .sort(helpers.sortByName);
+                                      .map(envVar => hide(envVar, authz))
+                                      .sort(helpers.sortByName);
                               }
                               if (container.ports) {
                                   container.ports = container.ports.map(port => portFieldDel(port, authz));
@@ -92,8 +93,8 @@ function get(req, res, next) {
                           result.providers = result.providers.map(provider => {
                               if (provider.envVars) {
                                   provider.envVars = provider.envVars
-                                  .map(envVar => hide(envVar, authz))
-                                  .sort(helpers.sortByName);
+                                      .map(envVar => hide(envVar, authz))
+                                      .sort(helpers.sortByName);
                               }
                               return provider;
                           });

--- a/routes/shipment.js
+++ b/routes/shipment.js
@@ -217,6 +217,7 @@ function bulk(req, res, next) {
                     promises = envVars.map((envVar) => {
                         envVar.composite = `${shipment.name}-${envVar.name}`;
                         envVar.shipmentId = shipment.name;
+                        envVar = helpers.prepEnvVar(envVar);
 
                         return models.EnvVar.upsert(envVar, {
                             transaction: taction,
@@ -264,6 +265,7 @@ function bulk(req, res, next) {
                         environment.envVars.map((envVar) => {
                             envVar.composite = `${environment.composite}-${envVar.name}`;
                             envVar.environmentId = `${environment.composite}`;
+                            envVar = helpers.prepEnvVar(envVar);
 
                             let promise = models.EnvVar.upsert(envVar, {
                                 transaction: taction,
@@ -450,6 +452,10 @@ function getUpserts(model, incoming, composite, foriegnKeyId, taction) {
 
         inc.composite = `${composite}-${inc.name}`;
         inc[foriegnKeyId] = composite;
+        if (model === 'EnvVar') {
+            // we need to make sure that Env Vars have their shaValue set
+            inc = helpers.prepEnvVar(inc);
+        }
         nowObjects.push({model: model, method: 'upsert', values: inc, options: options});
 
         if (model === 'Container') {

--- a/test/20.environments.js
+++ b/test/20.environments.js
@@ -68,6 +68,34 @@ describe('Environment', function () {
                 });
         });
 
+        it('should be able to create a EnvVar on an Environment', function (done) {
+            request(server)
+                .post(`/v1/shipment/${testShipment.name}/environment/${testEnvironment.name}/envVars`)
+                .set('x-username', authUser)
+                .set('x-token', authToken)
+                .send({"name": "NODE_ENV", "value": "development"})
+                .expect('Content-Type', /json/)
+                .expect(201, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    let data = res.body,
+                        props = ['name', 'value', 'type'],
+                        excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
+
+                    props.forEach(prop => expect(data).to.have.property(prop));
+                    excludes.forEach(prop => expect(data).to.not.have.property(prop));
+
+                    expect(data.name).to.equal('NODE_ENV');
+                    expect(data.value).to.equal('development');
+                    expect(data.type).to.equal('basic');
+
+                    done();
+                });
+        });
+
         it('should fail when trying to create the same Environment', function (done) {
             request(server)
                 .post(`/v1/shipment/${testShipment.name}/environments`)
@@ -264,7 +292,7 @@ describe('Environment', function () {
                     expect(data.name).to.equal(testEnvironment.name);
                     expect(data.parentShipment.group).to.equal(testShipment.group);
                     expect(data.parentShipment.name).to.equal(testShipment.name);
-                    expect(data.envVars).to.have.lengthOf(0);
+                    expect(data.envVars).to.have.lengthOf(1);
 
                     done();
                 });

--- a/test/30.containers.js
+++ b/test/30.containers.js
@@ -104,7 +104,7 @@ describe('Container', function () {
 
                     let data = res.body,
                         props = ['name', 'value', 'type'],
-                        excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId', 'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                        excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId', 'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -198,7 +198,7 @@ describe('Container', function () {
 
                     let data = res.body,
                         props = ['name', 'value', 'type'],
-                        excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId', 'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                        excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId', 'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -252,7 +252,7 @@ describe('Container', function () {
 
                     let data = res.body,
                         props = ['name', 'value', 'type'],
-                        excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId', 'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                        excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId', 'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));

--- a/test/40.providers.js
+++ b/test/40.providers.js
@@ -85,7 +85,7 @@ describe('Provider', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -161,7 +161,7 @@ describe('Provider', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -251,7 +251,7 @@ describe('Provider', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));

--- a/test/50.envVar.js
+++ b/test/50.envVar.js
@@ -56,7 +56,7 @@ describe('EnvVar', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -84,7 +84,7 @@ describe('EnvVar', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -152,7 +152,7 @@ describe('EnvVar', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -186,7 +186,7 @@ describe('EnvVar', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -228,7 +228,7 @@ describe('EnvVar', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));
@@ -255,7 +255,7 @@ describe('EnvVar', function () {
                     let data = res.body,
                         props = ['name', 'value', 'type'],
                         excludes = ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId',
-                            'createdAt', 'updatedAt', 'deletedAt', 'sha_value'];
+                            'createdAt', 'updatedAt', 'deletedAt', 'shaValue'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
                     excludes.forEach(prop => expect(data).to.not.have.property(prop));

--- a/test/60.bulk.js
+++ b/test/60.bulk.js
@@ -84,15 +84,15 @@ describe('Bulk', function () {
                     });
 
                     result = compare(data.envVars, body.envVars);
-                    expect(result, 'result').to.be.true;
+                    expect(result, 'compare(data.envVars, body.envVars)').to.be.true;
 
                     result = compare(data.providers, body.providers);
-                    expect(result, 'result').to.be.true;
+                    expect(result, 'compare(data.providers, body.providers)').to.be.true;
 
                     expect(body.parentShipment.name, 'body.parentShipment.name').to.equal(data.parentShipment.name);
 
                     result = compare(data.parentShipment.envVars, body.parentShipment.envVars);
-                    expect(result, 'result').to.be.true;
+                    expect(result, 'compare(data.parentShipment.envVars, body.parentShipment.envVars)').to.be.true;
 
                     expect(body.buildToken, 'body.buildToken').to.not.be.null;
                     expect(body.buildToken, 'body.buildToken').to.have.lengthOf(50);
@@ -102,7 +102,7 @@ describe('Bulk', function () {
                         let bodyContainer = body.containers[i];
 
                         result = compare(container.envVars, body.containers[i].envVars);
-                        expect(result, 'result').to.be.true;
+                        expect(result, 'compare(container.envVars, body.containers[i].envVars)').to.be.true;
                         expect(bodyContainer.name, 'bodyContainer.name').to.equal(container.name);
                         expect(bodyContainer.image, 'bodyContainer.image').to.equal(container.image);
 
@@ -491,7 +491,6 @@ describe('Bulk', function () {
                 .expect('Content-Type', /json/)
                 .expect(200, (err, res) => {
                     if (err) {
-                        console.log('err?', err);
                         return done(err);
                     }
 
@@ -975,8 +974,6 @@ describe('Bulk', function () {
                     }
 
                     let body = res.body;
-
-                    console.log('body.envVars', body.envVars);
 
                     expect(body.enableMonitoring, 'body.enableMonitoring').to.be.true;
                     expect(body.iamRole, 'body.iamRole').to.equal('arn:partition:service:region:account:resource');

--- a/test/70.logs.js
+++ b/test/70.logs.js
@@ -51,7 +51,7 @@ describe('Logs', function () {
                     let body = res.body;
 
                     expect(body).to.be.instanceOf(Array);
-                    expect(body.length).to.equal(27);
+                    expect(body.length).to.equal(28);
 
                     return done();
                 });
@@ -72,7 +72,7 @@ describe('Logs', function () {
                     let body = res.body;
 
                     expect(body).to.be.instanceOf(Array);
-                    expect(body.length).to.equal(20);
+                    expect(body.length).to.equal(21);
 
                     return done();
                 });

--- a/test/80.search.js
+++ b/test/80.search.js
@@ -44,22 +44,24 @@ describe('Search', function () {
 
                     let data = res.body;
 
-                    expect(data).to.have.length(2);
-
+                    expect(data, 'data').to.have.length(3);
                     data.forEach(ele => {
-                        expect(ele).to.be.an('object');
+                        expect(ele, 'data[][ele]').to.be.an('object');
                     });
 
-                    expect(data[0].environments).to.have.length(5);
-
+                    expect(data[0].environments, 'data[0].environments').to.have.length(4);
                     data[0].environments.forEach(ele => {
-                        expect(ele).to.be.an('object');
+                        expect(ele, 'data[0].environments[][ele]').to.be.an('object');
                     });
 
-                    expect(data[1].environments).to.have.length(1);
-
+                    expect(data[1].environments, 'data[1].environments').to.have.length(1);
                     data[1].environments.forEach(ele => {
-                        expect(ele).to.be.an('object');
+                        expect(ele, 'data[1].environments[][ele]').to.be.an('object');
+                    });
+
+                    expect(data[2].environments, 'data[2].environments').to.have.length(1);
+                    data[2].environments.forEach(ele => {
+                        expect(ele, 'data[2].environments[][ele]').to.be.an('object');
                     });
 
                     done();

--- a/test/80.search.js
+++ b/test/80.search.js
@@ -1,0 +1,69 @@
+/*global describe, it */
+
+const expect = require('chai').expect,
+    request = require('supertest'),
+    nock = require('nock'),
+    models = require('../models'),
+    helpers = require('./helpers'),
+    server = require('../app');
+
+let testShipment = helpers.fetchMockData('atomic-shipment-req'),
+    testEnvironment = helpers.fetchMockData('environment'),
+    envVar = helpers.fetchMockData('envVar'),
+    authUser = 'test_user',
+    authToken = 'foobar_token',
+    authnPostData = {username: authUser, token: authToken},
+    authnSuccess = { "success": true },
+    authnFailure = { "success": false },
+    authzSuccess = { groups_in: ['test', 'test-group'] };
+
+beforeEach(function () {
+    nock(helpers.getUrl('authn'))
+        .post('/v1/auth/checktoken', authnPostData)
+        .reply(200, (uri, requestBody) => {
+            return authnSuccess;
+        });
+
+    nock(helpers.getUrl('authz'))
+        .get(`/getUserGroups/${authUser}`)
+        .reply(200, (uri, requestBody) => {
+            return authzSuccess;
+        });
+});
+
+describe('Search', function () {
+    describe('Env Var', function () {
+        it('should return shipments from search', function (done) {
+            request(server)
+                .get(`/v1/envVar/search?NODE_ENV=development`)
+                .expect('Content-Type', /json/)
+                .expect(200, (err, res) => {
+                    if (err) {
+                        return done(err)
+                    }
+
+                    let data = res.body;
+
+                    expect(data).to.have.length(2);
+
+                    data.forEach(ele => {
+                        expect(ele).to.be.an('object');
+                    });
+
+                    expect(data[0].environments).to.have.length(5);
+
+                    data[0].environments.forEach(ele => {
+                        expect(ele).to.be.an('object');
+                    });
+
+                    expect(data[1].environments).to.have.length(1);
+
+                    data[1].environments.forEach(ele => {
+                        expect(ele).to.be.an('object');
+                    });
+
+                    done();
+                })
+        });
+    });
+});

--- a/test/mocks/bulk/1.shipment_provider.json
+++ b/test/mocks/bulk/1.shipment_provider.json
@@ -13,13 +13,7 @@
       }
     ]
   },
-  "envVars": [
-    {
-      "name": "NODE_ENV",
-      "value": "development",
-      "type": "basic"
-    }
-  ],
+  "envVars": [],
   "providers": [
     {
       "replicas": 2,
@@ -29,6 +23,11 @@
         {
           "name": "LOCATION",
           "value": "ec2",
+          "type": "basic"
+        },
+        {
+          "name": "NODE_ENV",
+          "value": "development",
           "type": "basic"
         }
       ]

--- a/test/mocks/bulk/2.shipment_2providers.json
+++ b/test/mocks/bulk/2.shipment_2providers.json
@@ -13,13 +13,7 @@
       }
     ]
   },
-  "envVars": [
-    {
-      "name": "NODE_ENV",
-      "value": "development",
-      "type": "basic"
-    }
-  ],
+  "envVars": [],
   "providers": [
     {
       "replicas": 2,

--- a/test/mocks/bulk/4.shipment_2containers.json
+++ b/test/mocks/bulk/4.shipment_2containers.json
@@ -13,13 +13,7 @@
       }
     ]
   },
-  "envVars": [
-    {
-      "name": "NODE_ENV",
-      "value": "development",
-      "type": "basic"
-    }
-  ],
+  "envVars": [],
   "providers": [],
   "containers": [
     {
@@ -29,6 +23,11 @@
         {
           "name": "HEALTHCHECK",
           "value": "/",
+          "type": "basic"
+        },
+        {
+          "name": "NODE_ENV",
+          "value": "development",
           "type": "basic"
         }
       ],

--- a/test/mocks/bulk_shipment.json
+++ b/test/mocks/bulk_shipment.json
@@ -106,6 +106,10 @@
         "name": "PORT_3",
         "value": "8082",
         "type": "basic"
+      },
+      {
+        "name": "NODE_ENV",
+        "value": "development"
       }
     ]
   }

--- a/test/sql-table.js
+++ b/test/sql-table.js
@@ -1,0 +1,20 @@
+/*global describe, it */
+
+const expect = require('chai').expect,
+    db = require('../models').sequelize;
+
+describe('SQL Table', function () {
+    describe('EnvVar', function () {
+        it('should have a value for every `shaValue`', function (done) {
+            db.query('SELECT "composite", "shaValue" FROM "EnvVars"', { type: db.QueryTypes.SELECT })
+                .then(envVars => {
+                    envVars.forEach(envVar => {
+                        expect(envVar.shaValue, `composite ${envVar.composite} has "shaValue" === null`).to.not.be.null;
+                    });
+
+                    done();
+                })
+                .catch(reason => done(reason));
+        });
+    });
+});


### PR DESCRIPTION
We now set the `shaValue` of every Env Var during creation and updating to allow for path `/v1/envVar/search` to be enabled. It still only searches Env Vars set on the Environment (although all Env Vars have their `shaValue` set (this could potentially open up the door for future searches to return Env Vars that are set anywhere on a Shipment.

There is a script to make it easy to add `shaValue` to all existing Env Vars.