### PR TITLE
DNS

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -166,6 +166,12 @@ iamRole
 - description: IAM ARN to be assumed by the container for permissions to cloud resources
 - requirement: must be a valid ARN
 
+dns
+- type:        String
+- required:    false
+- description: What type of DNS server to use foamr a Shipment.
+- requirement: must either be 'host' or 'cluster'
+
 ```
 
 
@@ -746,6 +752,12 @@ iamRole
 - required:    false
 - description: IAM ARN to be assumed by the container for permissions to cloud resources
 - requirement: must be a valid ARN
+
+dns
+- type:        String
+- required:    false
+- description: What type of DNS server to use foamr a Shipment.
+- requirement: must either be 'host' or 'cluster'
 
 ```
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -169,7 +169,7 @@ iamRole
 dns
 - type:        String
 - required:    false
-- description: What type of DNS server to use foamr a Shipment.
+- description: What type of DNS server to use for a Shipment.
 - requirement: must either be 'host' or 'cluster'
 
 ```
@@ -756,7 +756,7 @@ iamRole
 dns
 - type:        String
 - required:    false
-- description: What type of DNS server to use foamr a Shipment.
+- description: What type of DNS server to use for a Shipment.
 - requirement: must either be 'host' or 'cluster'
 
 ```

--- a/MODELS.md
+++ b/MODELS.md
@@ -23,6 +23,7 @@ There are several types of objects that are related to a Shipment in ShipIt.
     "buildToken":       "String. Long lived auth token.",
     "enableMonitoring": "Boolean. Whether alerts should be sent to DOC when Shipment is failing; defaults to true.",
     "iamRole":          "String. IAM Role ARN that the container will assume for permissions to cloud resources",
+    "dns":              "String. What type of DNS server to use for the Shipment.",
     "envVars":          "Array. Env Var objects.",
     "annotations":      "Array. Annotation objects.",
     "containers":       "Array. Container objects.",

--- a/lib/mappers.js
+++ b/lib/mappers.js
@@ -15,6 +15,7 @@ module.exports = {
                 buildToken: env.buildToken || null,
                 enableMonitoring: env.enableMonitoring || false,
                 iamRole: env.iamRole || "",
+                dns: env.dns || "host",
                 envVars: env.envVars || [],
                 annotations: env.annotations || [],
                 containers: env.containers || [],

--- a/migrations/20171020161500-dns.js
+++ b/migrations/20171020161500-dns.js
@@ -4,7 +4,7 @@ module.exports = {
 
         queryInterface.describeTable('Environments').then(attributes => {
           if (!attributes.hasOwnProperty('dns')) {
-            // iamRole
+            // dns
             changes.push(
                 queryInterface.addColumn(
                     'Environments',

--- a/migrations/20171020161500-dns.js
+++ b/migrations/20171020161500-dns.js
@@ -1,0 +1,33 @@
+module.exports = {
+    up: function (queryInterface, DataTypes) {
+        let changes = [];
+
+        queryInterface.describeTable('Environments').then(attributes => {
+          if (!attributes.hasOwnProperty('dns')) {
+            // iamRole
+            changes.push(
+                queryInterface.addColumn(
+                    'Environments',
+                    'dns',
+                    {
+                        type: DataTypes.STRING,
+                        field: "dns",
+                        defaultValue: "cluster",
+                        get() {
+                            return this.getDataValue('dns') || this.getDataValue('value');
+                        }
+                    }
+                )
+            );
+          }
+        });
+
+        return Promise.all(changes);
+    },
+
+    down: function (queryInterface, DataTypes) {
+        let changes = [];
+
+        return Promise.all(changes);
+    }
+};

--- a/models/environment.js
+++ b/models/environment.js
@@ -42,6 +42,11 @@ module.exports = (sequelize, DataTypes) => {
                 type: DataTypes.JSONB,
                 field: "annotations",
                 defaultValue: []
+            },
+            dns: {
+                type: DataTypes.STRING,
+                defaultValue: "host",
+                allowNull: false
             }
         },
         {

--- a/models/environment.js
+++ b/models/environment.js
@@ -46,7 +46,10 @@ module.exports = (sequelize, DataTypes) => {
             dns: {
                 type: DataTypes.STRING,
                 defaultValue: "host",
-                allowNull: false
+                allowNull: false,
+                validate: {
+                    isIn: [['host', 'cluster']]
+                }
             }
         },
         {

--- a/routes/shipment.js
+++ b/routes/shipment.js
@@ -132,7 +132,7 @@ function get(req, res, next) {
         options = {
             where: { name: req.params.shipment },
             include: [
-                { model: models.Environment, as: 'environments', attributes: { exclude: ['buildToken', 'composite', 'enableMonitoring', 'iamRole', 'shipmentId'] } },
+                { model: models.Environment, as: 'environments', attributes: { exclude: ['buildToken', 'composite', 'enableMonitoring', 'iamRole', 'dns', 'shipmentId'] } },
                 { model: models.EnvVar, as: 'envVars', attributes: { exclude: helpers.excludes.envVar(authz) } }
             ]
         };

--- a/test/20.environments.js
+++ b/test/20.environments.js
@@ -52,7 +52,7 @@ describe('Environment', function () {
                     }
 
                     let data = res.body,
-                        props = ['name', 'enableMonitoring', 'iamRole', 'buildToken'],
+                        props = ['name', 'enableMonitoring', 'iamRole', 'dns', 'buildToken'],
                         excludes = ['composite', 'shipmentId', 'createdAt', 'updatedAt', 'deletedAt'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
@@ -61,6 +61,7 @@ describe('Environment', function () {
                     expect(data.name).to.equal('test-env');
                     expect(data.enableMonitoring).to.equal(true);
                     expect(data.iamRole).to.not.be.null;
+                    expect(data.dns).to.not.be.null;
                     expect(data.buildToken).to.not.be.null;
                     expect(data.buildToken).to.have.lengthOf(50);
 
@@ -165,6 +166,7 @@ describe('Environment', function () {
                 .set('x-token', authToken)
                 .send({"enableMonitoring": "false"})
                 .send({"iamRole": "arn:partition:service:region:account:resource"})
+                .send({"dns": "cluster"})
                 .expect('Content-Type', /json/)
                 .expect(200, (err, res) => {
                     if (err) {
@@ -172,7 +174,7 @@ describe('Environment', function () {
                     }
 
                     let data = res.body,
-                        props = ['name', 'enableMonitoring', 'iamRole', 'buildToken', 'buildToken'],
+                        props = ['name', 'enableMonitoring', 'iamRole', 'dns', 'buildToken', 'buildToken'],
                         excludes = ['composite', 'shipmentId', 'createdAt', 'updatedAt', 'deletedAt'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));
@@ -180,6 +182,7 @@ describe('Environment', function () {
 
                     expect(data.enableMonitoring).to.equal(false);
                     expect(data.iamRole).to.equal("arn:partition:service:region:account:resource");
+                    expect(data.dns).to.equal("cluster");
                     expect(data.buildToken).to.not.be.null;
                     expect(data.buildToken).to.be.lengthOf(50);
 
@@ -251,6 +254,7 @@ describe('Environment', function () {
                         .set('x-token', authToken)
                         .send({"enableMonitoring": "false"})
                         .send({"iamRole": "arn:partition:service:region:account:resource"})
+                        .send({"dns": "cluster"})
                         .expect('Content-Type', /json/)
                         .expect(200, (err, res) => {
                             if (err) {
@@ -261,6 +265,7 @@ describe('Environment', function () {
 
                             expect(data.buildToken).to.not.be.null;
                             expect(data.iamRole).to.equal("arn:partition:service:region:account:resource");
+                            expect(data.dns).to.equal("cluster");
                             expect(data.buildToken).to.be.lengthOf(50);
                             expect(data.buildToken).to.not.equal(content.buildToken);
 
@@ -313,7 +318,7 @@ describe('Environment', function () {
                     }
 
                     let data = res.body,
-                        props = ['name', 'enableMonitoring', 'iamRole', 'parentShipment', 'envVars'],
+                        props = ['name', 'enableMonitoring', 'iamRole', 'dns', 'parentShipment', 'envVars'],
                         excludes = ['composite', 'shipmentId', 'buildToken', 'createdAt', 'updatedAt', 'deletedAt'];
 
                     props.forEach(prop => expect(data).to.have.property(prop));

--- a/test/60.bulk.js
+++ b/test/60.bulk.js
@@ -49,7 +49,7 @@ describe('Bulk', function () {
                         result;
 
                     let props = {
-                            environment: ['name', 'enableMonitoring', 'iamRole', 'buildToken', 'envVars', 'containers', 'providers'],
+                            environment: ['name', 'enableMonitoring', 'iamRole', 'dns', 'buildToken', 'envVars', 'containers', 'providers'],
                             parentShipment: ['name', 'group', 'envVars'],
                             container: ['name', 'image', 'envVars', 'ports'],
                             provider: ['name', 'replicas', 'barge', 'envVars'],
@@ -542,7 +542,7 @@ describe('Bulk', function () {
 
                     let body = res.body;
                         props = {
-                            environment: ['name', 'enableMonitoring', 'iamRole', 'envVars', 'containers', 'providers'],
+                            environment: ['name', 'enableMonitoring', 'iamRole', 'dns', 'envVars', 'containers', 'providers'],
                             parentShipment: ['name', 'group', 'envVars'],
                             container: ['name', 'image', 'envVars', 'ports'],
                             provider: ['name', 'replicas', 'barge', 'envVars'],
@@ -620,7 +620,7 @@ describe('Bulk', function () {
 
                     let body = res.body;
                         props = {
-                            environment: ['name', 'enableMonitoring', 'iamRole', 'buildToken', 'envVars', 'containers', 'providers'],
+                            environment: ['name', 'enableMonitoring', 'iamRole', 'dns', 'buildToken', 'envVars', 'containers', 'providers'],
                             parentShipment: ['name', 'group', 'envVars'],
                             container: ['name', 'image', 'envVars', 'ports'],
                             provider: ['name', 'replicas', 'barge', 'envVars'],
@@ -704,7 +704,7 @@ describe('Bulk', function () {
                         },
                         excludes = {
                             shipment: ['composite'],
-                            environment: ['composite', 'shipmentId', 'enableMonitoring', 'iamRole', 'buildToken', 'envVars', 'containers', 'providers'],
+                            environment: ['composite', 'shipmentId', 'enableMonitoring', 'iamRole', 'dns', 'buildToken', 'envVars', 'containers', 'providers'],
                             envVar: ['composite', 'containerId', 'environmentId', 'providerId', 'shipmentId']
                         };
 
@@ -840,6 +840,7 @@ describe('Bulk', function () {
 
                     expect(body.enableMonitoring, 'body.enableMonitoring').to.be.false;
                     expect(body.iamRole, 'body.iamRole').to.equal('arn:partition:service:region:account:resource');
+                    expect(body.dns, 'body.dns').to.equal('host');
                     expect(body.name, 'body.name').to.equal('test');
 
                     expect(body.parentShipment.name, 'body.parentShipment.name').to.equal('bulk-test-app');
@@ -894,6 +895,7 @@ describe('Bulk', function () {
 
                     expect(body.enableMonitoring, 'body.enableMonitoring').to.be.false;
                     expect(body.iamRole, 'body.iamRole').to.equal('arn:partition:service:region:account:resource');
+                    expect(body.dns, 'body.dns').to.equal('host');
                     expect(body.name, 'body.name').to.equal('test');
 
                     expect(body.parentShipment.name, 'body.parentShipment.name').to.equal('bulk-test-app');
@@ -950,6 +952,7 @@ describe('Bulk', function () {
 
                     expect(body.enableMonitoring, 'body.enableMonitoring').to.be.true;
                     expect(body.iamRole, 'body.iamRole').to.equal('arn:partition:service:region:account:resource');
+                    expect(body.dns, 'body.dns').to.equal('host');
                     expect(body.name, 'body.name').to.equal('test');
                     expect(body.parentShipment.name, 'body.parentShipment.name').to.equal('bulk-test-app');
                     expect(body.parentShipment.group, 'body.parentShipment.group').to.equal('test');
@@ -980,6 +983,7 @@ describe('Bulk', function () {
 
                     expect(body.enableMonitoring, 'body.enableMonitoring').to.be.true;
                     expect(body.iamRole, 'body.iamRole').to.equal('arn:partition:service:region:account:resource');
+                    expect(body.dns, 'body.dns').to.equal('host');
                     expect(body.name, 'body.name').to.equal('test');
                     expect(body.parentShipment.name, 'body.parentShipment.name').to.equal('bulk-test-app');
                     expect(body.parentShipment.group, 'body.parentShipment.group').to.equal('test');
@@ -1011,6 +1015,7 @@ describe('Bulk', function () {
 
                     expect(body.enableMonitoring, 'body.enableMonitoring').to.be.false;
                     expect(body.iamRole, 'body.iamRole').to.equal('arn:partition:service:region:account:resource');
+                    expect(body.dns, 'body.dns').to.equal('host');
                     expect(body.name, 'body.name').to.equal('test');
 
                     expect(body.parentShipment.name, 'body.parentShipment.name').to.equal('bulk-test-app');
@@ -1065,6 +1070,7 @@ describe('Bulk', function () {
 
                     expect(body.enableMonitoring, 'body.enableMonitoring').to.be.false;
                     expect(body.iamRole, 'body.iamRole').to.equal('arn:partition:service:region:account:resource');
+                    expect(body.dns, 'body.dns').to.equal('host');
                     expect(body.name, 'body.name').to.equal('test');
 
                     expect(body.parentShipment.name, 'body.parentShipment.name').to.equal('bulk-test-app');

--- a/test/mocks/bulk_shipment.json
+++ b/test/mocks/bulk_shipment.json
@@ -3,6 +3,7 @@
   "buildToken": null,
   "enableMonitoring": true,
   "iamRole": "arn:partition:service:region:account:resource",
+  "dns": "host",
   "envVars": [
     {
       "name": "PORT",

--- a/test/mocks/bulk_shipment5.json
+++ b/test/mocks/bulk_shipment5.json
@@ -3,6 +3,7 @@
   "buildToken": null,
   "enableMonitoring": true,
   "iamRole": "arn:partition:service:region:account:resource",
+  "dns": "host",
   "envVars": [
     {
       "name": "PORT",

--- a/test/scripts/runThrough.sh
+++ b/test/scripts/runThrough.sh
@@ -40,7 +40,7 @@ main() {
     call 'POST' '/v1/shipment/foo/environment/baz/container/webapp/ports' "@test/mocks/models/port.json"
     call 'PUT' '/v1/shipment/foo/environment/baz/container/webapp/port/PORT' '{"public_port": 8080, "ssl_arn": "bar"}'
     call 'POST' '/v1/bulk/shipments' "@test/mocks/models/bulk_shipment.json"
-    call 'PUT' '/v1/shipment/foo/environment/back' '{"enableMonitoring": "false", "iamRole": "arn:partition:service:region:account:resource"}'
+    call 'PUT' '/v1/shipment/foo/environment/back' '{"enableMonitoring": "false", "iamRole": "arn:partition:service:region:account:resource", "dns": "host"}'
     call 'PUT' '/v1/shipment/foo/environment/back' '{"enableMonitoring": "true"}'
     echo 'Done!'
 }


### PR DESCRIPTION
Change default DNS options to use host DNS rather than cluster.  This will improve the DNS responsiveness.  Users can still opt in to using cluster DNS if they need it.