### PR TITLE
fix(order): add an order by statement to all queries

### DIFF
--- a/routes/annotation.js
+++ b/routes/annotation.js
@@ -93,7 +93,7 @@ function post(req, res, next) {
                     arr.push(obj.key);
                     return arr;
                 }, []).join(',');
-                environment.annotations = body;
+                environment.annotations = body.sort(orderBy);
             }
             else {
                 let temp = environment.annotations || []
@@ -116,7 +116,7 @@ function post(req, res, next) {
                 }
 
                 req.params.name = body.key;
-                environment.annotations = temp;
+                environment.annotations = temp.sort(orderBy);
             }
 
             helpers.updateAuditLog(was, environment.annotations, req);
@@ -157,7 +157,7 @@ function put(req, res, next) {
             }
 
             // setting all annotations
-            environment.annotations = temp;
+            environment.annotations = temp.sort(orderBy);
 
             req.params.name = req.params.annotation;
             helpers.updateAuditLog(was, environment.annotations, req);
@@ -197,3 +197,21 @@ function deleteIt(req, res, next) {
         .then(handler.updated(res, `Annotations not updated. Query ${query.where.composite} failed.`))
         .catch(reason => next(reason));
 }
+
+
+/**
+ * orderBy
+ *
+ * Order by key
+ */
+ function orderBy(a, b) {
+     if (a.key > b.key) {
+         return 1;
+     }
+     else if (a.key < b.key) {
+         return -1;
+     }
+     else {
+         return 0;
+     }
+ }

--- a/routes/container.js
+++ b/routes/container.js
@@ -24,6 +24,11 @@ function get(req, res, next) {
         query = {
             attributes: { exclude: helpers.excludes.container(authz) },
             where: { composite: getComposite(req.params) },
+            order: [
+                ['composite', 'ASC'],
+                [{ model: models.EnvVar, as: "envVars" }, 'composite', 'ASC'],
+                [{ model: models.Port, as: "ports" }, 'composite', 'ASC']
+            ],
             include: [
               { model: models.EnvVar, as: "envVars", attributes: { exclude: helpers.excludes.envVar(authz) } },
               { model: models.Port, as: "ports", attributes: { exclude: helpers.excludes.port(authz) } }

--- a/routes/envVar.js
+++ b/routes/envVar.js
@@ -362,10 +362,10 @@ function search (req, res, next) {
                 object.environments =  object.environments.map((environment) => {
                     environment.envVars = environment.envVars.map((envVar) => helpers.toHideValue(envVar, authz))
                     environment.providers = environment.providers.map((provider) => {
-                        provider.envVars.map((envVar) => helpers.toHideValue(envVar, authz)) 
+                        provider.envVars.map((envVar) => helpers.toHideValue(envVar, authz))
                     });
                     environment.containers = environment.containers.map((container) => {
-                        container.envVars.map((envVar) => helpers.toHideValue(envVar, authz)) 
+                        container.envVars.map((envVar) => helpers.toHideValue(envVar, authz))
                     });
                 });
                 return object;

--- a/routes/environment.js
+++ b/routes/environment.js
@@ -43,7 +43,7 @@ function get(req, res, next) {
 
                   payload.parentShipment = shipment.toJSON();
                   delete payload.parentShipment.id;
-                
+
                   // if user is not authed, hide iam role
                   if (!authz) {
                       payload.iamRole = helpers.hideValue();
@@ -286,6 +286,10 @@ function _get(req, type, ship, env) {
         query = {
             shipment: {
                 where: { name: ship },
+                order: [
+                    ['name', 'ASC'],
+                    [{ model: models.EnvVar, as: 'envVars' }, 'composite', 'ASC']
+                ],
                 include: [
                     { model: models.EnvVar, as: 'envVars', attributes: { exclude: helpers.excludes.envVar(authz) } }
                 ]
@@ -293,6 +297,15 @@ function _get(req, type, ship, env) {
             environment: {
                 attributes: { exclude: helpers.excludes.environment(authz) },
                 where: { composite: `${ship}-${env}` },
+                order: [
+                    ['name', 'ASC'],
+                    [{ model: models.EnvVar, as: 'envVars' }, 'composite', 'ASC'],
+                    [{ model: models.Provider, as: 'providers' }, 'composite', 'ASC'],
+                    [{ model: models.Provider, as: 'providers' }, { model: models.EnvVar, as: 'envVars' }, 'composite', 'ASC'],
+                    [{ model: models.Container, as: 'containers'}, 'composite', 'ASC'],
+                    [{ model: models.Container, as: 'containers'}, { model: models.EnvVar, as: 'envVars' }, 'composite', 'ASC'],
+                    [{ model: models.Container, as: 'containers'}, { model: models.Port, as: 'ports' }, 'composite', 'ASC'],
+                ],
                 include: [
                     { model: models.EnvVar, as: "envVars", attributes: { exclude: helpers.excludes.envVar(authz) } },
                     { model: models.Provider, as: "providers", attributes: { exclude: helpers.excludes.provider(authz) }, include: [

--- a/routes/provider.js
+++ b/routes/provider.js
@@ -24,6 +24,10 @@ function get(req, res, next) {
         query = {
             attributes: { exclude: helpers.excludes.provider(authz) },
             where: { composite: getComposite(req.params) },
+            order: [
+                ['composite', 'ASC'],
+                [{ model: models.EnvVar, as: 'envVars' }, 'composite', 'ASC']
+            ],
             include: [
               { model: models.EnvVar, as: "envVars", attributes: { exclude: helpers.excludes.envVar(authz) } }
             ]

--- a/routes/shipment.js
+++ b/routes/shipment.js
@@ -26,6 +26,10 @@ module.exports = router;
 function getAll(req, res, next) {
     let query = {
             attributes: { exclude: ['composite'] },
+            order: [
+                ['name', 'ASC'],
+                [{ model: models.Environment, as: 'environments' }, 'composite', 'ASC']
+            ],
             include: [
                 {
                     model: models.Environment,
@@ -131,6 +135,11 @@ function get(req, res, next) {
     let authz = req.authorized || null,
         options = {
             where: { name: req.params.shipment },
+            order: [
+                ['name', 'ASC'],
+                [{ model: models.Environment, as: 'environments' }, 'composite', 'ASC'],
+                [{ model: models.EnvVar, as: 'envVars' }, 'composite', 'ASC']
+            ],
             include: [
                 { model: models.Environment, as: 'environments', attributes: { exclude: ['buildToken', 'composite', 'enableMonitoring', 'iamRole', 'shipmentId'] } },
                 { model: models.EnvVar, as: 'envVars', attributes: { exclude: helpers.excludes.envVar(authz) } }

--- a/test/90.order.js
+++ b/test/90.order.js
@@ -1,0 +1,164 @@
+/*global describe, it */
+
+const expect = require('chai').expect,
+    request = require('supertest'),
+    nock = require('nock'),
+    models = require('../models'),
+    helpers = require('./helpers'),
+    server = require('../app');
+
+describe('Order', function () {
+    // Shipment
+    it('should be enforced on Shipments', function (done) {
+        request(server)
+            .get('/v1/shipments')
+            .expect('Content-Type', /json/)
+            .expect(200, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let data = res.body,
+                    names = ['bulk-shipment-app', 'bulk-test-app', 'foo'],
+                    envs = [
+                        ['test0', 'test1', 'test2', 'test3', 'test4', 'test5', 'test6'],
+                        ['test'],
+                        ['back']
+                    ];
+
+                data.forEach((ele, i) => {
+                    expect(ele.name, `ele.name == names[${i}]`).to.equal(names[i]);
+
+                    ele.environments.forEach((env, j) => {
+                        expect(env, `env == env[${j}]`).to.equal(envs[i][j])
+                    });
+                });
+
+                done();
+            });
+    });
+
+    it('should be enforced on a Shipment', function (done) {
+        request(server)
+            .get('/v1/shipment/foo')
+            .expect('Content-Type', /json/)
+            .expect(200, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let data = res.body,
+                    envVars = ['NODE_ENV', 'PORT', 'PORT_3'];
+
+                data.envVars.forEach((envVar, i) => {
+                    expect(envVar.name, 'name == envVars[i]').to.equal(envVars[i])
+                });
+
+                done();
+            });
+    });
+
+    // Environment
+    it('should be enforced on Environment (providers)', function (done) {
+        request(server)
+            .get('/v1/shipment/bulk-shipment-app/environment/test2')
+            .expect('Content-Type', /json/)
+            .expect(200, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let data = res.body,
+                    providers = ['aws:us-east-1', 'aws:us-east-2'];
+
+                data.providers.forEach((provider, i) => {
+                    expect(provider.name, 'name == provider[i]').to.equal(providers[i]);
+                });
+
+                done();
+            });
+
+    });
+
+    it('should be enforced on Environment (containers)', function (done) {
+        request(server)
+            .get('/v1/shipment/bulk-shipment-app/environment/test4')
+            .expect('Content-Type', /json/)
+            .expect(200, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let data = res.body,
+                    containers = ['hello-world-app', 'sidecar-app'];
+
+                data.containers.forEach((container, i) => {
+                    expect(container.name, 'name == container[i]').to.equal(containers[i]);
+                });
+
+                done();
+            });
+    });
+
+    // Ports
+    it('should be enforced on Ports', function (done) {
+        //  PORT PORT_SSL
+        request(server)
+            .get('/v1/shipment/foo/environment/back')
+            .expect('Content-Type', /json/)
+            .expect(200, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let data = res.body,
+                    ports = ['PORT', 'PORT_SSL'];
+
+                data.containers[0].ports.forEach((port, i) => {
+                    expect(port.name, 'port name == ports[i]').to.equal(ports[i])
+                });
+
+                done();
+            });
+    });
+
+
+    // EnvVars
+    it('should be enforced on EnvVars', function (done) {
+        request(server)
+            .get('/v1/shipment/bulk-test-app/environment/test')
+            .expect('Content-Type', /json/)
+            .expect(200, (err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let data = res.body,
+                    envVars = {
+                        shipment: ['CUSTOMER', 'MY_SECRET'],
+                        environment: ['MY_SECRET', 'NODE_ENV'],
+                        container: ['HEALTHCHECK', 'MY_SECRET'],
+                        provider: ['LOCATION', 'MY_SECRET']
+                    };
+
+                data.envVars.forEach((ele, i) => {
+                    expect(ele.name, 'environment envVar name == ele[i]').to.equal(envVars.environment[i])
+                });
+
+                data.parentShipment.envVars.forEach((ele, i) => {
+                    expect(ele.name, 'shipment envVar name == ele[i]').to.equal(envVars.shipment[i])
+                });
+
+                data.containers[0].envVars.forEach((ele, i) => {
+                    expect(ele.name, 'container envVar name == ele[i]').to.equal(envVars.container[i])
+                });
+
+                data.providers[0].envVars.forEach((ele, i) => {
+                    expect(ele.name, 'provider envVar name == ele[i]').to.equal(envVars.provider[i])
+                });
+
+
+                done();
+            });
+    });
+});


### PR DESCRIPTION
We want the ShipIt API to always return entries in arrays in the same order, so adding order statements to all queries.