### PR TITLE
fix(annotations): do not allow empty annotations to be saved

### DIFF
--- a/routes/shipment.js
+++ b/routes/shipment.js
@@ -253,6 +253,17 @@ function bulk(req, res, next) {
                         environment.buildToken = shipment.environments[0].buildToken || helpers.generateToken();
                     }
 
+                    // Annotations
+                    if (environment.annotations && environment.annotations.length) {
+                        environment.annotations = environment.annotations.reduce((acc, val) => {
+                            if (typeof val.key !== 'undefined' && typeof val.value !== 'undefined') {
+                                acc.push(val);
+                            }
+
+                            return acc;
+                        }, []);
+                    }
+
                     let promise = models.Environment.upsert(environment, {
                         transaction: taction,
                         include: _include(shipName, envName, 'environments').include

--- a/test/25.annotations.js
+++ b/test/25.annotations.js
@@ -111,6 +111,16 @@ describe('Annotation', function () {
                 .expect('Content-Type', /json/)
                 .expect(400, done);
         });
+
+        it('should fail if sending empty objects', function (done) {
+            request(server)
+                .post(`/v1/shipment/${testShipment.name}/environment/${testEnvironment.name}/annotations`)
+                .set('x-username', authUser)
+                .set('x-token', authToken)
+                .send([{}, {"key": "annotation.test.key.2", "value": "this is two"}])
+                .expect('Content-Type', /json/)
+                .expect(400, done);
+        });
     });
 
     describe('Read', function () {

--- a/test/60.bulk.js
+++ b/test/60.bulk.js
@@ -354,6 +354,36 @@ describe('Bulk', function () {
                 });
         });
 
+        it('should create Shipment, but not include empty annotations', function (done) {
+            request(server)
+                .post('/v1/bulk/shipments')
+                .set('x-username', authUser)
+                .set('x-token', authToken)
+                .send(helpers.fetchMockData('bulk/12.shipment_annotations.failure'))
+                .expect('Content-Type', /json/)
+                .expect(201, (err, res) => {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    request(server)
+                        .get('/v1/shipment/bulk-shipment-app/environment/test12')
+                        .expect('Content-Type', /json/)
+                        .expect(200, (err, res) => {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            let body = res.body;
+
+                            expect(body.annotations).to.be.an('array').with.lengthOf(1);
+                            expect(body.annotations[0]).to.deep.equal({"key": "foobar", "value": "foobar value"});
+
+                            done();
+                        });
+                });
+        });
+
         it('should fail when creating Shipment Environment if missing required fields', function (done) {
             request(server)
                 .post('/v1/bulk/shipments')

--- a/test/70.logs.js
+++ b/test/70.logs.js
@@ -91,7 +91,7 @@ describe('Logs', function () {
 
                     expect(body).to.be.instanceOf(Array);
                     expect(body[0].diff).to.equal("*******")
-                    expect(body.length).to.equal(9);
+                    expect(body.length).to.equal(10);
 
                     return done();
                 });

--- a/test/mocks/bulk/12.shipment_annotations.failure.json
+++ b/test/mocks/bulk/12.shipment_annotations.failure.json
@@ -1,0 +1,58 @@
+{
+  "enableMonitoring": false,
+  "iamRole": "arn:partition:service:region:account:resource",
+  "name": "test12",
+  "parentShipment": {
+    "name": "bulk-shipment-app",
+    "group": "test",
+    "envVars": [
+      {
+        "name": "CUSTOMER",
+        "value": "mss",
+        "type": "basic"
+      }
+    ]
+  },
+  "annotations": [
+    {},
+    {
+      "key": "foobar",
+      "value": "foobar value"
+    }
+  ],
+  "envVars": [
+    {
+      "name": "NODE_ENV",
+      "value": "production",
+      "type": "basic"
+    }
+  ],
+  "providers": [
+    {
+      "replicas": 2,
+      "barge": "test",
+      "name": "aws:us-east-1",
+      "envVars": [
+        {
+          "name": "LOCATION",
+          "value": "ec2",
+          "type": "basic"
+        }
+      ]
+    }
+  ],
+  "containers": [
+    {
+      "image": "registry.services.dmtio.net/hello-world:0.1.0",
+      "name": "hello-world-app",
+      "envVars": [
+        {
+          "name": "HEALTHCHECK",
+          "value": "/",
+          "type": "basic"
+        }
+      ],
+      "ports": []
+    }
+  ]
+}


### PR DESCRIPTION
Solving issue #52 

Currently, the bulk endpoint allows for annotations to be empty. No longer save empty annotations.