### PR TITLE
fix(limit): allow bigger payloads

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,7 +12,7 @@ const app = express();
 app.set('x-powered-by', false);
 app.set('etag', false);
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({limit: '3mb'}));
 app.use(cors());
 
 app.get('/_hc', middleware.health);


### PR DESCRIPTION
Going from default `100kb` to `3mb`.