### PR TITLE
fix(format): allow the log format to be configured

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,8 @@ const express = require('express'),
     morgan = require('morgan'),
     cors = require('cors');
 
+const logFormat = process.env.MORGAN_FORMAT || 'short';
+
 global.status = 200;
 global.appError = null;
 
@@ -17,7 +19,7 @@ app.use(cors());
 
 app.get('/_hc', middleware.health);
 
-app.use(morgan('short'));
+app.use(morgan(logFormat));
 
 const routes = require('./routes'),
     shipment = require('./routes/shipment'),


### PR DESCRIPTION
To help solve issue #57 

Currently, our logging is rather simplistic, we see this…
```
:remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] - :response-time ms
```

This change will allow us to either use one of [Morgan's](xxx) predefined formats or create our own. Once this is merged in, I'd like to see us use `combined` in production so we can see this…
```
:remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"
```